### PR TITLE
Bug 693654 - Add OpenSearch plugin for Mozillians

### DIFF
--- a/media/opensearch.xml
+++ b/media/opensearch.xml
@@ -1,0 +1,10 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>Mozillians</ShortName>
+  <LongName>Mozillians</LongName>
+  <Description>Search people on Mozillians</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16">http://mozillians.org/media/favicon.ico</Image>
+  
+  <Url type="text/html" template="http://mozillians.org/search?q={searchTerms}&amp;x=0&amp;y=0"/>
+
+</OpenSearchDescription>

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,8 @@
   {% endblock %}
 
   <link rel="shortcut icon" type="image/ico" href="{{ MEDIA_URL }}favicon.ico">
+  <link rel="search" type="application/opensearchdescription+xml"
+      href="{{ MEDIA_URL }}opensearch.xml" title="Mozillians.org" />
   {% block feeds %}{% endblock %}
   {% block extra_headers %}{% endblock %}
 </head>


### PR DESCRIPTION
- Stuck [Antoine Turmel's search plugin](https://addons.mozilla.org/en-US/firefox/addon/mozillians/) into media/opensearch.xml
- Added the discovery header to `templates/base.html`

This is the quick & simple version. If we wanted to get fancy, I could generate `opensearch.xml` in a view, point the URLs at the local instance, write tests, etc. But, that seemed like overkill.
