### PR TITLE
Bug 693654 - Add OpenSearch plugin for Mozillians

### DIFF
--- a/apps/phonebook/templates/phonebook/search_opensearch.xml
+++ b/apps/phonebook/templates/phonebook/search_opensearch.xml
@@ -1,0 +1,14 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http:/www.mozilla.org/2006/browser/search/">
+    <ShortName>{{ _('Mozillians') }}</ShortName>
+    <LongName>{{ _('Mozillians') }}</LongName>
+    {# L10n: The description for the OpenSearch plugin. #}
+    <Description>{{ _('Search people on Mozillians') }}</Description>
+    <InputEncoding>UTF-8</InputEncoding>
+    <Image width="16" height="16">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAV1BMVEUAAAAEBASGhoYiIiIzAAAzMzPAwMDx8fHMAACZAABmAACgoKQEBASAAAD/MwAMDAz/AADMMwDMADNVVVX///9mMzN3d3cAMwBmZmYWFhaZADMzMwCZMwA1dyFFAAAAAnRSTlMAAHaTzTgAAAABYktHRBSS38k1AAAACXBIWXMAAABIAAAASABGyWs+AAAAlUlEQVQY021PWw7CMAxr17QkWUMzupXxuP85STcYEsIflmzZeTj3D0OAOKRDniIgIQO8rTEzsZyFQ9mNnFlxIrnUQJseMqkKT8bI1poLTGpChVCVgiV6wAwo1TKLmwOQgjkC0BZil1MRRRUj4XZd3ZxLn4A3qO3+GPuW1AsI7bi0gQ14hu8nKZIF6kd6QxIpq9/h/A9e+uYHtMcRhIoAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTEtMTAtMTJUMTE6NDc6MzgtMDQ6MDD+94OvAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDExLTEwLTEyVDExOjQ3OjM4LTA0OjAwj6o7EwAAAABJRU5ErkJggg==</Image>
+    <Url type="text/html" 
+         template="{{ request.build_absolute_uri(url('phonebook.search')) }}?q={searchTerms}"/>
+    <Url type="application/opensearchdescription+xml" rel="self" 
+        template="{{ request.build_absolute_uri(url('phonebook.search_plugin')) }}"/>
+    <moz:SearchForm>{{ request.build_absolute_uri(url('phonebook.search')) }}</moz:SearchForm>
+</OpenSearchDescription>

--- a/apps/phonebook/urls.py
+++ b/apps/phonebook/urls.py
@@ -19,6 +19,7 @@ urlpatterns = patterns('',
         name='phonebook.edit_new_profile'),
     url('^confirm-delete$', views.confirm_delete, name='confirm_delete'),
     url('^delete$', views.delete, name='phonebook.delete_profile'),
+    url('^opensearch.xml$', views.search_plugin, name='phonebook.search_plugin'),
     url('^search$', views.search, name='phonebook.search'),
     url('^vouch$', views.vouch, name='phonebook.vouch'),
 

--- a/apps/phonebook/views.py
+++ b/apps/phonebook/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import (Http404, HttpResponse, HttpResponseRedirect,
                          HttpResponseForbidden)
 from django.shortcuts import redirect, render
-from django.views.decorators.cache import never_cache
+from django.views.decorators.cache import cache_page, never_cache
 from django.views.decorators.http import require_POST
 
 import commonware.log
@@ -232,6 +232,13 @@ def search(request):
              form=form,
              size_exceeded_error=size_exceeded)
     return render(request, 'phonebook/search.html', d)
+
+
+@cache_page(60 * 60 * 168) # 1 week.
+def search_plugin(request):
+    """Render an OpenSearch Plugin."""
+    return render(request, 'phonebook/search_opensearch.xml',
+                  content_type='application/opensearchdescription+xml')
 
 
 @login_required

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,6 +13,8 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="apple-touch-icon" href="{{ MEDIA_URL }}apple-touch-icon.png">
+  <link rel="search" type="application/opensearchdescription+xml" 
+        title="{{ _('Mozillians') }}" href="{{ url('phonebook.search_plugin') }}">
 
   {% block site_css %}
     {{ css('common') }}


### PR DESCRIPTION
- Kitsune-inspired view, template, and test for localized
  OpenSearch plugin
- Link for OpenSearch plugin in templates/base.html

Having trouble getting LDAP running in my VM, but the plain-vanilla test case passes for me. Also, I couldn't figure out how to force-change the locale for use by Funfactory's reverse(), so I fell back to Django's reverse()
