### PR TITLE
Show vouched users as Mozillians (fix bug 704194)

### DIFF
--- a/apps/phonebook/templates/phonebook/profile.html
+++ b/apps/phonebook/templates/phonebook/profile.html
@@ -10,7 +10,7 @@
   <h1>
     {% if user.unique_id == person.unique_id %}
       {{ _('Your Profile') }}
-    {% elif person.voucher %}
+    {% elif person.get_profile().is_vouched %}
       {{ _('Mozillian Profile') }}
     {% else %}
       {{ _('Pending Profile') }}

--- a/apps/users/tests.py
+++ b/apps/users/tests.py
@@ -226,8 +226,18 @@ class VouchTest(LDAPTestCase):
         """
         vouchee = get_profile(MOZILLIAN['email'])
         profile = get_profile(PENDING['email'])
-        assert not profile.is_vouched
+        assert not profile.is_vouched, 'User should not yet be vouched.'
 
         profile.vouch(vouchee)
         profile = get_profile(PENDING['email'])
         assert profile.is_vouched, 'User should be marked as vouched.'
+
+        r = self.mozillian_client.get(reverse('profile',
+                                              args=[PENDING['uniq_id']]))
+        doc = pq(r.content)
+        assert 'Mozillian Profile' in r.content, (
+                'User should appear as having a vouched profile.')
+        assert not 'Pending Profile' in r.content, (
+                'User should not appear as having a pending profile.')
+        assert not doc('#pending-approval'), (
+                'Pending profile div should not be in DOM.')


### PR DESCRIPTION
Crummy regression; it's in the test suite now.
