### PR TITLE
Add support for hCard 'url' property and rel="me" microformats, try 2.

### DIFF
--- a/apps/phonebook/templates/phonebook/profile.html
+++ b/apps/phonebook/templates/phonebook/profile.html
@@ -90,7 +90,8 @@
         {% if profile.website %}
           <dt class="website">{{ _('Website') }}</dt>
           <dd class="website">
-            <a href="{{ profile.website }}">{{ profile.website }}</a>
+            <a class="url u-url" rel="me" href="{{ profile.website }}">
+            {{ profile.website }}</a>
           </dd>
         {% endif %}
 


### PR DESCRIPTION
Add support for hCard[1] 'url' property and rel="me"[2] microformats to semantically express feature implemented by bug 690357, with a line break to keep code < 80 char/line.

[1] http://microformats.org/wiki/hcard
[2] http://microformats.org/wiki/rel-me
