### PR TITLE
Fixes bug 709248

### DIFF
--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -12,7 +12,10 @@ auth_views.render_to_response = jinja_for_django
 
 urlpatterns = patterns('',
     url(r'^logout$', views.logout, name='logout'),
-    url(r'^confirm$', redirect_to, dict(dict(url='/', name='home'))),
+    url(r'^confirm$', redirect_to, dict(url='/', name='home')),
+    # This sucks: we should not have to do this, but a lot of people/libraries/
+    # existing code is looking for this view.
+    url(r'^login$', redirect_to, dict(url='/', name='home'), name='login'),
     url(r'^register$', views.register, name='register'),
     # TODO: remove in 1.4 release, legacy url sent in emails
     url(r'^password_reset_confirm/'

--- a/settings/default.py
+++ b/settings/default.py
@@ -143,7 +143,7 @@ SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
 # Auth
-LOGIN_URL = '/login'
+LOGIN_URL = '/'
 LOGIN_REDIRECT_URL = '/'
 
 CACHES = {


### PR DESCRIPTION
Two issues needed to be fixed for this bug:
1) settings was trying to redirect people to /login
2) we had no view there, we need something that works for
reverse('login')
