### PR TITLE
Fix 713090 (search box in chrome)

### DIFF
--- a/apps/phonebook/templates/phonebook/search.html
+++ b/apps/phonebook/templates/phonebook/search.html
@@ -22,7 +22,7 @@
 
   <div class="blue-pastels">
     <form method="GET" id="search-form" action="{{ url('search') }}">
-      <input name="q" id="q"
+      <input type="text" name="q" id="q"
         placeholder="{{ _('Name, IRC Nick, or Email') }}" autofocus
         value="{% if form.cleaned_data %}{{ form.cleaned_data.q }}{% endif %}">
       <input type="hidden" name="limit" id="limit" value="{{ limit }}">


### PR DESCRIPTION
Something about the useragent stylesheet is different in the mac version
versus other versions of chrome. In the mac version, it latches on to
type="search" argument in the HTML and makes it look sexy. Linux and mac don't do
that, in fact they mess up the search box to look dumb. It seemed to be
easier to just remove it. Now it looks the same in firefox/chrome on mac and firefox/chrome on linux mint. I will get QA community to verify this on dev because it is very difficult for me to properly verify windows.
