### PR TITLE
Fix 724123 (Vouched By line in Profile)

### DIFF
--- a/apps/phonebook/templates/phonebook/profile.html
+++ b/apps/phonebook/templates/phonebook/profile.html
@@ -99,15 +99,12 @@
           <dd>{{ profile.location }}</dd>
         {% endif %}
 
-        {% if not profile.voucher and profile.is_vouched %}
-          <dt>{{ _('Vouched by') }}</dt>
-          <dd>{{ _('No longer active') }}</dd>
-        {% elif profile.voucher %}
+        {% if profile.vouched_by %}
           <dt>{{ _('Vouched by') }}</dt>
           <dd>
-            <a href="{{ url('profile', shown_user.username) }}"
+            <a href="{{ url('profile', profile.vouched_by.user.username) }}"
                class="vouched">
-              {{ profile.voucher.full_name }}
+              {{ profile.vouched_by.display_name }}
             </a>
           </dd>
         {% endif %}


### PR DESCRIPTION
This is a slight change in intended functionality: If your voucher up and leaves, it just doesn't show anything instead of saying "No longer active". This happens frequently because nobody with a mozilla.com username has an active voucher.
