### PR TITLE
Use Django's username rules (fix bug 733408)

### DIFF
--- a/apps/phonebook/forms.py
+++ b/apps/phonebook/forms.py
@@ -64,8 +64,8 @@ class UserForm(forms.ModelForm):
             raise forms.ValidationError(_('This username is in use. Please try'
                                           ' another.'))
 
-        # No funky characters in username
-        if not re.match(r'^\w+$', username):
+        # No funky characters in username.
+        if not re.match(r'^[\w.@+-]+$', username):
             raise forms.ValidationError(_('Please use only alphanumeric'
                                           ' characters'))
 

--- a/apps/phonebook/urls.py
+++ b/apps/phonebook/urls.py
@@ -33,5 +33,5 @@ urlpatterns = patterns('',
     url('^$', anonymous_csrf(direct_to_template),
         {'template': 'phonebook/home.html'}, name='home'),
 
-    url(r'^(?P<username>(u\/)?[\w\-]+)$', views.profile, name='profile'),
+    url(r'^(?P<username>(u\/)?[\w.@+-]{1,30})$', views.profile, name='profile'),
 )


### PR DESCRIPTION
Allow some more flexible characters in Django username/URLs. Any thoughts?
