### PR TITLE
Fix bug741006 - username doesn't show up on profile

### DIFF
--- a/apps/phonebook/templates/phonebook/profile.html
+++ b/apps/phonebook/templates/phonebook/profile.html
@@ -83,6 +83,11 @@
           </a></dd>
         {% endif %}
 
+        {% if not shown_user.username.startswith('u/') %}
+          <dt>{{ _('Username') }}</dt>
+          <dd>{{ shown_user.username }}</dd>
+        {% endif %}
+
         {% if profile.ircname %}
           <dt>{{ _('IRC Nickname') }}</dt>
           <dd><a href="irc://irc.mozilla.org/">


### PR DESCRIPTION
Regression - username doesn't show up in profile view.
