### PR TITLE
Fixes skiplink

### DIFF
--- a/media/css/base.css
+++ b/media/css/base.css
@@ -30,6 +30,22 @@ body {
     font:16px/24px Georgia, serif;
 }
 
+.skip{
+	position:absolute;
+	left:-999em;
+}
+.skip:focus{
+	left:0;
+	right:0;
+	top:0;
+	padding-top:5px;
+	height:35px;
+	text-align:center;
+	background:rgb(255,255,255);
+	color:rgb(44,44,44);
+	z-index:1031; /* one more than .nav-bar-fixed-top */
+}
+
 .huge,.large,h1,h2,h3,h4 {
     font-family:OpenSans, "Lucida Sans", "Lucida Grande", "Lucida Sans Unicode", Verdana, sans-serif;
     font-weight:400;

--- a/templates/base.html
+++ b/templates/base.html
@@ -30,9 +30,7 @@
   {{ 'auth' if user.is_authenticated() else 'anon' }}"
   data-locale="{{ LANG }}">
 
-<ul id="skip" class="hide">
-  <li><a href="#main">{{ _('Skip to Content') }}</a></li>
-</ul>
+<a class="skip" href="#main">{{ _('Skip to Content') }}</a>
 {% block nav %}
   <nav class="navbar navbar-fixed-top">
     <div class="navbar-inner">


### PR DESCRIPTION
skiplink that has display:none is useless because it will never receive
focus. I also added a visual :focus state.

This commit fixes [bug 745888] Make skip-navigation link tab-selectable.
