### PR TITLE
Fix CSP reporting and a CSP violation.

### DIFF
--- a/settings/default.py
+++ b/settings/default.py
@@ -122,6 +122,11 @@ MIDDLEWARE_CLASSES = list(base.MIDDLEWARE_CLASSES) + [
 # StrictTransport
 STS_SUBDOMAINS = True
 
+# Not all URLs need locale.
+SUPPORTED_NONLOCALES = list(base.SUPPORTED_NONLOCALES) + [
+    'csp',
+]
+
 AUTHENTICATION_BACKENDS = ('common.backends.MozilliansBrowserID',)
 
 # BrowserID creates a user if one doesn't exist.
@@ -202,7 +207,8 @@ SOUTH_TESTS_MIGRATE = False
 CSP_IMG_SRC = ("'self'", 'http://statse.webtrendslive.com',
                'https://statse.webtrendslive.com',)
 CSP_SCRIPT_SRC = ("'self'", 'http://statse.webtrendslive.com',
-                  'https://statse.webtrendslive.com',)
+                  'https://statse.webtrendslive.com',
+                  'https://browserid.org',)
 CSP_REPORT_ONLY = True
 CSP_REPORT_URI = '/csp/report'
 


### PR DESCRIPTION
Noticed this while getting everything set up.
1) browserid JS was violating CSP
2) reports were failing because of LocaleURLMiddleware.

Fixes both.
