### PR TITLE
Jenkins es competition

### DIFF
--- a/bin/jenkins.sh
+++ b/bin/jenkins.sh
@@ -100,7 +100,7 @@ export FORCE_DB=1
 if [ -z $COVERAGE ]; then
     python manage.py test --noinput --with-xunit --logging-clear-handlers
 else
-    coverage run manage.py test --noinput --with-xunit --logging-clear-handlers
+    coverage run --omit='*migrations*' manage.py test --noinput --with-xunit --logging-clear-handlers
     coverage xml --omit='*migrations*' $(find apps lib -name '*.py')
 fi
 


### PR DESCRIPTION
Right now the two Jenkins builds use the same ES index, so if they run at the same time, they clobber each other and tests fail. This should fix that.
