### PR TITLE
[fix bug 762080] Fix saving UserProfiles in admin.

### DIFF
--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -6,9 +6,17 @@ from users.models import UserProfile
 
 
 class UserProfileAdmin(AdminImageMixin, admin.ModelAdmin):
+    fields = ['user', 'user_email', 'display_name', 'photo', 'ircname',
+              'is_vouched', 'vouched_by', 'bio', 'website', 'groups', 'skills']
     list_display = ['display_name', 'user_email', 'user_username', 'ircname',
                     'is_vouched', 'vouched_by']
     list_display_links = ['display_name', 'user_email', 'user_username']
+    readonly_fields=['user', 'user_email']
+    save_on_top = True
     search_fields = ['display_name', 'user_email', 'user_username', 'ircname']
+
+    def has_add_permission(self, *a, **kw):
+        """No one should be creating UserProfiles from the admin."""
+        return False
 
 admin.site.register(UserProfile, UserProfileAdmin)

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -36,10 +36,10 @@ class UserProfile(SearchMixin, models.Model):
 
     # Foreign Keys and Relationships
     vouched_by = models.ForeignKey('UserProfile', null=True, default=None,
-                                   on_delete=models.SET_NULL)
+                                   on_delete=models.SET_NULL, blank=True)
 
-    groups = models.ManyToManyField('groups.Group')
-    skills = models.ManyToManyField('groups.Skill')
+    groups = models.ManyToManyField(Group, blank=True)
+    skills = models.ManyToManyField(Skill, blank=True)
     bio = models.TextField(verbose_name=_lazy(u'Bio'), default='', blank=True)
     photo = ImageField(default='', blank=True, storage=fs,
                        upload_to='userprofile')


### PR DESCRIPTION
On master, you can't actually save a `UserProfile` in the admin if they have no skills or groups or vouched_by defined.
- Make nullable fields as blank=True.
- Make non-changeable fields readonly in admin.
- Remove ability to create new UserProfiles via admin. Doesn't make sense.
- Fix some ManyToMany declarations in UserProfile.
