### PR TITLE
[fix bug 762234] Prevent deleting UserProfiles.

### DIFF
--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -19,4 +19,8 @@ class UserProfileAdmin(AdminImageMixin, admin.ModelAdmin):
         """No one should be creating UserProfiles from the admin."""
         return False
 
+    def has_delete_permission(self, *a, **kw):
+        """Delete the User, not the UserProfile."""
+        return False
+
 admin.site.register(UserProfile, UserProfileAdmin)


### PR DESCRIPTION
UserProfile objects shouldn't be deleted via the admin, they should only be
deleted by deleting the associated user.
