### PR TITLE
Clarify where data in UserProfileAdmin comes from.

### DIFF
--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -6,12 +6,12 @@ from users.models import UserProfile
 
 
 class UserProfileAdmin(AdminImageMixin, admin.ModelAdmin):
-    fields = ['user', 'user__email', 'display_name', 'photo', 'ircname',
+    fields = ['user', 'user_email', 'display_name', 'photo', 'ircname',
               'is_vouched', 'vouched_by', 'bio', 'website', 'groups', 'skills']
-    list_display = ['display_name', 'user__email', 'user__username', 'ircname',
+    list_display = ['display_name', 'user_email', 'user_username', 'ircname',
                     'is_vouched', 'vouched_by']
-    list_display_links = ['display_name', 'user__email', 'user__username']
-    readonly_fields = ['user', 'user__email']
+    list_display_links = ['display_name', 'user_email', 'user_username']
+    readonly_fields = ['user', 'user_email']
     save_on_top = True
     search_fields = ['display_name', 'user__email', 'user__username',
                      'ircname']

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -75,10 +75,10 @@ class UserProfile(SearchMixin, models.Model):
     def get_absolute_url(self):
         return reverse('profile', args=[self.user.username])
 
-    def user__email(self):
+    def user_email(self):
         return self.user.email
 
-    def user__username(self):
+    def user_username(self):
         return self.user.username
 
     def anonymize(self):


### PR DESCRIPTION
Makes callables on the UserProfile model look distinct from typical
double-underscore lookups. Different options on ModelAdmin behave
differently, so this should make it clearer which option is using which
data source.

This partially reverts c957841878f6486c74f8a70caa5c95a408aff0c9 but should keep the same functionality.
