### PR TITLE
Show popular groups on 404 page

### DIFF
--- a/apps/groups/models.py
+++ b/apps/groups/models.py
@@ -54,6 +54,12 @@ class Group(GroupBase):
     wiki = models.URLField(max_length=200, verbose_name=_lazy(u'Wiki'),
             default='', blank=True)
 
+    @classmethod
+    def get_curated(cls):
+        """Return all the groups with a steward assigned"""
+        return cls.objects.exclude(steward=None).annotate(
+            num_users=models.Count('userprofile')).order_by('-num_users')
+
     class Meta:
         db_table = 'group'
 

--- a/apps/phonebook/templates/phonebook/search.html
+++ b/apps/phonebook/templates/phonebook/search.html
@@ -42,8 +42,8 @@
         {% endfor %}
       </div>
     </form>
-    <div class="row">
-      {% if not form.cleaned_data %}
+    {% if not form.cleaned_data.q %}
+      <div class="well">
         {% trans %}
           <h2>Search For a Mozillian</h2>
 
@@ -54,16 +54,38 @@
         {% endtrans %}
       {% else %}
         {% for person in people %}
+          {% if loop.first %}
+            <div class="row">
+          {% endif %}
           {{ search_result(person) }}
         {% else %}
-          <p id="not-found">
-            {% trans invite=url('invite') %}
-              The Mozillian you are looking for is not in the directory.
-              Please check your spelling or
+        <div class="well">
+          {% trans invite=url('invite'), query=form.cleaned_data.q %}
+            <p id="not-found">
+              Sorry, we cannot find a group or person with "{{ query }}" in their names.
+            </p>
+            <p>
+              Maybe they're not a Mozillian yet? Invite them
               <a href="{{ invite }}">invite this person</a> to create a profile.
-            {% endtrans %}
-          </p>
+            </p>
+          {% endtrans %}
         {% endfor %}
+        {% if groups %}
+          <hr>
+          <h3>{{ _('Search groups with stewards') }}</h3>
+          <div class="popular-groups">
+            <ul id="groups" class="tagit ui-widget ui-corner-all">
+              {% for group in groups %}
+                <li class="tagit-choice ui-widget-content ui-state-default
+                           ui-corner-all p-category category">
+                  <a href="{{ url('group', group.id, group.url) }}">
+                    {{ group.name }}
+                  </a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
 
         {% if show_pagination %}
           <div data-pages={{ num_pages }} class="pagination">

--- a/apps/phonebook/views.py
+++ b/apps/phonebook/views.py
@@ -18,6 +18,7 @@ from tastypie.models import ApiKey
 from tower import ugettext as _
 
 from groups.helpers import stringify_groups
+from groups.models import Group
 from phonebook import forms
 from phonebook.models import Invite
 from users.models import UserProfile
@@ -167,7 +168,8 @@ def search(request):
             profiles = UserProfile.search(query,
                                           vouched=vouched,
                                           photo=profilepic)
-
+            if not profiles:
+                groups = Group.get_curated()
             paginator = Paginator(profiles, limit)
 
             try:
@@ -184,6 +186,8 @@ def search(request):
             if paginator.count > forms.PAGINATION_LIMIT:
                 show_pagination = True
                 num_pages = len(people.paginator.page_range)
+        else:
+            groups = Group.get_curated()
 
     d = dict(people=people,
              form=form,
@@ -191,7 +195,8 @@ def search(request):
              nonvouched_only=nonvouched_only,
              picture_only=picture_only,
              show_pagination=show_pagination,
-             num_pages=num_pages)
+             num_pages=num_pages,
+             groups=groups)
 
     if request.is_ajax():
         return render(request, 'search_ajax.html', d)

--- a/media/css/base.css
+++ b/media/css/base.css
@@ -587,3 +587,7 @@ label, input, button, select, textarea {
     width: 33%;
     margin: 0;
 }
+
+.popular-groups {
+    padding: 10px 0;
+}


### PR DESCRIPTION
Show the popular groups, defined as groups with a steward, in descending order of number of members.
