### PR TITLE
Prevent CSP violation from login.persona.org

### DIFF
--- a/settings/default.py
+++ b/settings/default.py
@@ -221,8 +221,10 @@ CSP_IMG_SRC = ("'self'", 'http://statse.webtrendslive.com',
                'https://secure.gravatar.com',)
 CSP_SCRIPT_SRC = ("'self'", 'http://statse.webtrendslive.com',
                   'https://statse.webtrendslive.com',
-                  'https://browserid.org',)
-CSP_FRAME_SRC = ("'self'", 'https://browserid.org',)
+                  'https://browserid.org',
+                  'https://login.persona.org',)
+CSP_FRAME_SRC = ("'self'", 'https://browserid.org',
+                 'https://login.persona.org',)
 CSP_REPORT_ONLY = True
 CSP_REPORT_URI = '/csp/report'
 


### PR DESCRIPTION
Seeing CSP errors from `login.persona.org` in the CSP email reports. This'll patch that up.
