### PR TITLE
Bug779948

### DIFF
--- a/media/css/base.css
+++ b/media/css/base.css
@@ -1,32 +1,32 @@
 @font-face{
     font-family:'Open Sans Light';
-    src:url('../fonts/OpenSans-Light-webfont.eot');
-    src:url('../fonts/OpenSans-Light-webfont.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/OpenSans-Light-webfont.woff') format('woff'),
-        url('../fonts/OpenSans-Light-webfont.ttf') format('truetype'),
-        url('../fonts/OpenSans-Light-webfont.svg#OpenSansLight') format('svg');
+    src:url('//www.mozilla.org/img/fonts/OpenSans-Light-webfont.eot');
+    src:url('//www.mozilla.org/img/fonts/OpenSans-Light-webfont.eot?#iefix') format('embedded-opentype'),
+        url('//www.mozilla.org/img/fonts/OpenSans-Light-webfont.woff') format('woff'),
+        url('//www.mozilla.org/img/fonts/OpenSans-Light-webfont.ttf') format('truetype'),
+        url('//www.mozilla.org/img/fonts/OpenSans-Light-webfont.svg#OpenSansLight') format('svg');
     font-weight:300;
     font-style:normal
 }
 
 @font-face{
     font-family:'Open Sans';
-    src:url('../fonts/OpenSans-Regular-webfont.eot');
-    src:url('../fonts/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/OpenSans-Regular-webfont.woff') format('woff'),
-        url('../fonts/OpenSans-Regular-webfont.ttf') format('truetype'),
-        url('../fonts/OpenSans-Regular-webfont.svg#OpenSansRegular') format('svg');
+    src:url('//www.mozilla.org/img/fonts/OpenSans-Regular-webfont.eot');
+    src:url('//www.mozilla.org/img/fonts/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype'),
+        url('//www.mozilla.org/img/fonts/OpenSans-Regular-webfont.woff') format('woff'),
+        url('//www.mozilla.org/img/fonts/OpenSans-Regular-webfont.ttf') format('truetype'),
+        url('//www.mozilla.org/img/fonts/OpenSans-Regular-webfont.svg#OpenSansRegular') format('svg');
     font-weight:normal;
     font-style:normal
 }
 
 @font-face{
     font-family:'Open Sans';
-    src:url('../fonts/OpenSans-Semibold-webfont.eot');
-    src:url('../fonts/OpenSans-Semibold-webfont.eot?#iefix') format('embedded-opentype'),
-        url('../fonts/OpenSans-Semibold-webfont.woff') format('woff'),
-        url('../fonts/OpenSans-Semibold-webfont.ttf') format('truetype'),
-        url('../fonts/OpenSans-Semibold-webfont.svg#OpenSansSemibold') format('svg');
+    src:url('//www.mozilla.org/img/fonts/OpenSans-Semibold-webfont.eot');
+    src:url('//www.mozilla.org/img/fonts/OpenSans-Semibold-webfont.eot?#iefix') format('embedded-opentype'),
+        url('//www.mozilla.org/img/fonts/OpenSans-Semibold-webfont.woff') format('woff'),
+        url('//www.mozilla.org/img/fonts/OpenSans-Semibold-webfont.ttf') format('truetype'),
+        url('//www.mozilla.org/img/fonts/OpenSans-Semibold-webfont.svg#OpenSansSemibold') format('svg');
     font-weight:bold;
     font-style:normal
 }


### PR DESCRIPTION
Fixes Bug779948 Open Sans font family in mozillians.org does not include non-English characters

This is using the full OpenSans font we now use on mozilla.org, the added advantage is that Mozillians are likely to visit mozilla.org frequently and have the font already cached.

We have CORS headers already set up on mozilla.org for an external use of the font:

curl -I www.mozilla.org/img/fonts/OpenSans-Regular-webfont.woff | grep Access-Control-Allow-Origin

Access-Control-Allow-Origin: \*  
