### PR TITLE
Fix typo in doc: runserver url

### DIFF
--- a/docs/installation-virtualenv.rst
+++ b/docs/installation-virtualenv.rst
@@ -75,7 +75,7 @@ You 'll need python, virtualenv and pip.
 
 	  ./manage.py runserver 127.0.0.1:8000
 
-     #. Load http://127.0.0.1:800 and sign in with BrowserID, then create your profile.
+     #. Load http://127.0.0.1:8000 and sign in with BrowserID, then create your profile.
      #. Run::
 
 	  ./scripts/su.sh


### PR DESCRIPTION
The runserver url in the documentation misses a "0" in the port number
