### PR TITLE
Revert "[fix bug 768536] Add ES_TIMEOUT and ES_INDEXING_TIMEOUT."

### DIFF
--- a/apps/users/cron.py
+++ b/apps/users/cron.py
@@ -17,7 +17,7 @@ def index_all_profiles():
     # Get an es object, delete index and re-create it
 
     index = settings.ES_INDEXES['default']
-    es = get_es(timeout=settings.ES_INDEXING_TIMEOUT)
+    es = get_es()
     try:
         es.delete_index_if_exists(index)
     except pyes.exceptions.IndexMissingException:

--- a/settings/default.py
+++ b/settings/default.py
@@ -255,8 +255,3 @@ THUMBNAIL_PREFIX = 'uploads/sorl-cache/'
 
 # This is for the commons/helper.py thumbnail.
 DEFAULT_IMAGE_SRC = path('./media/uploads/unknown.png')
-
-# Timeout for querying requests
-ES_TIMEOUT = 5
-# Timeout for indexing requests
-ES_INDEXING_TIMEOUT = 30

--- a/settings/local.py-devdist
+++ b/settings/local.py-devdist
@@ -46,7 +46,6 @@ ES_DISABLED = False
 ES_HOSTS = ['127.0.0.1:9200']
 ES_INDEXES = dict(default='mozillians_dev')
 ES_TIMEOUT = 60
-ES_INDEXING_TIMEOUT = 60
 
 CELERY_ALWAYS_EAGER = True
 
@@ -60,3 +59,4 @@ CACHES = {
         'LOCATION': 'unique-pastry-chef'
         }
 }
+


### PR DESCRIPTION
This reverts commit eccd02b0a7ee4a30cfb6645fb72fa34541333c5f.

Default ES_TIMEOUT == 5 should be enough, no need for separate
ES_INDEXING_TIMEOUT.
