### PR TITLE
Updated virtualenv docs with non-404 link to elasticsearch 0.19.4

### DIFF
--- a/docs/installation-virtualenv.rst
+++ b/docs/installation-virtualenv.rst
@@ -57,7 +57,7 @@ You 'll need python, virtualenv and pip.
 
 #. Download and run elastic search::
 
-     (venv)$ wget https://github.com/downloads/elasticsearch/elasticsearch/elasticsearch-0.19.4.tar.gz -O /tmp/es.tar.gz
+     (venv)$ wget http://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-0.19.4.tar.gz -O /tmp/es.tar.gz
      (venv)$ tar xvf /tmp/es.tar.gz -C venv/
      (venv)$ ./venv/elasticsearch-0.19.4/bin/elasticsearch -p venv/es.pid >/dev/null 2>&1
 


### PR DESCRIPTION
I tried getting the tarball from github, but ran into a 404. This worked for me, albeit with http instead of https.
