### PR TITLE
[bug 844806] Rename "Settings" link to "Edit Your Profile"

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -85,7 +85,7 @@
                     <li class="divider"></li>
                     <li>
                       <a id="edit_profile" href="{{ url('profile.edit') }}">
-                        {{ _('Settings') }}
+                        {{ _('Edit Your Profile') }}
                       </a>
                     </li>
                     <li>


### PR DESCRIPTION
As discussed in bug 844806, "Settings" option in Profile dropdown (top
right corner), when user is authenticated, creates confusion as it
points to the same Edit Profile page. So, renaming it to "Edit Your
Profile" makes the purpose clear.

The OP of bug 844806 had suggested to keep only one link to Edit Profile
page, but a link in the Profile name dropdown will come handy for users
even if links (or buttons) leading to the edit profile page exist on
other pages.
