### PR TITLE
[bug 846263] Reduce font size of profile headings

### DIFF
--- a/media/css/base.css
+++ b/media/css/base.css
@@ -96,7 +96,7 @@ h2 {
     margin-bottom:5px;
 }
 
-h3, #profile-info dt {
+h3 {
     font-size:28px;
     letter-spacing:-.5px;
     line-height:100%;
@@ -609,6 +609,9 @@ legend {
 
 #profile-info h3, #profile-info dt {
     margin: 20px 0 10px 0;
+    font-size:22px;
+    letter-spacing:-.5px;
+    line-height:100%;
 }
 
 .search-options {


### PR DESCRIPTION
Font size of profile page headings have been reduced to 22px to make it
the name more prominent than the rest of the profile fields.

Change done in reference to comment on attachment 721192.
