### PR TITLE
[fix bug 846039] Authorization routes for Profile View.

### DIFF
--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -12,6 +12,9 @@ from tower import ugettext as _
 
 from apps.groups.models import Group, GroupAlias
 
+LOGIN_MESSAGE = _('You must be logged in to continue.')
+GET_VOUCHED_MESSAGE = _('You must be vouched to continue.')
+
 
 class StrongholdMiddleware(object):
     """Keep unvouched users out, unless explicitly allowed in.
@@ -33,7 +36,7 @@ class StrongholdMiddleware(object):
             return None
 
         if not request.user.is_authenticated():
-            messages.warning(request, _('You must be logged in to continue.'))
+            messages.warning(request, LOGIN_MESSAGE)
             return login_required(view_func)(request, *view_args,
                                              **view_kwargs)
 
@@ -44,7 +47,7 @@ class StrongholdMiddleware(object):
         if allow_unvouched:
             return None
 
-        messages.error(request, _('You must be vouched to continue.'))
+        messages.error(request, GET_VOUCHED_MESSAGE)
         return redirect('home')
 
 

--- a/apps/phonebook/urls.py
+++ b/apps/phonebook/urls.py
@@ -31,5 +31,5 @@ urlpatterns = patterns('',
     url('^about/$', allow_public(direct_to_template),
         {'template': 'phonebook/about.html'}, name='about'),
     url(r'^u/(?P<username>[\w.@+-]+)/$',
-        views.profile, name='profile'),
+        views.view_profile, name='profile'),
 )


### PR DESCRIPTION
- Allow all users to visit public profiles.
- Allow all users visit own profile.
- Redirect anonymous and unvouched users when requesting private or non-existent profile
- Raise 404 when vouched user requests non-existent profile
