### PR TITLE
[bug 859973] Improve Groups Listing view

### DIFF
--- a/apps/groups/templates/groups/index.html
+++ b/apps/groups/templates/groups/index.html
@@ -8,6 +8,23 @@
   {% if groups %}
     <h1>{{ _('Group Listing') }}</h1>
 
+    <div class="sort">
+        <form method="get" action="{{ request.path }}">
+            <input type="hidden" name="page" value="{{ page }}" />
+            <label for="sort">Sort by:</label>
+            <select name="sort">
+                {% for key, value in sort_choices.items() %}
+                <option value="{{ key }}"
+                        {% if sort_by == key %}
+                        selected="selected"
+                        {% endif %}
+                        >{{ value }}</option>
+                {% endfor %}
+            </select>
+            <input type="submit" class="btn" value="Sort" />
+        </form>
+    </div>
+
     <p>
       {% trans %}
         Mozillians work on all sorts of different things! From Add-on
@@ -16,13 +33,15 @@
       {% endtrans %}
     </p>
 
-    <ul id="groups" class="tagit ui-widget ui-widget-content ui-corner-all">
+    <ul id="groups" class="group-list">
       {% for group in groups %}
-        <li class="tagit-choice ui-widget-content ui-state-default
-                   ui-corner-all">
-          <a href="{{ url('group', group.url) }}">
+        <li class="group-item">
+          <a href="{{ url('group', group.url) }}" class="group-name">
             {{ group.name }}
-          </a>
+          </a>  &mdash;
+          <span>
+              <i class="icon-user-md"></i>{{ group.members.vouched().count() }}
+          </span>
         </li>
       {% endfor %}
     </ul>

--- a/apps/groups/views.py
+++ b/apps/groups/views.py
@@ -20,7 +20,15 @@ log = commonware.log.getLogger('m.groups')
 
 def index(request):
     """Lists all public groups (in use) on Mozillians."""
-    paginator = Paginator(Group.objects.all(), forms.PAGINATION_LIMIT)
+
+    sort_by = request.GET.get('sort', 'name')
+    sort_choices = {"name": "Group Name A-Z",
+                    "-num_members": "Most Members",
+                    "num_members": "Fewest Members"}
+
+    paginator = Paginator(Group.objects.annotate(num_members=Count('members'))
+                          .order_by(sort_by, 'name'),
+                          forms.PAGINATION_LIMIT_LARGE)
 
     page = request.GET.get('page')
     try:
@@ -30,7 +38,8 @@ def index(request):
     except EmptyPage:
         groups = paginator.page(paginator.num_pages)
 
-    data = dict(groups=groups)
+    data = dict(groups=groups, sort_by=sort_by, page=page,
+                sort_choices=sort_choices)
     return render(request, 'groups/index.html', data)
 
 
@@ -109,6 +118,7 @@ def toggle(request, url):
             profile.groups.remove(group)
         else:
             profile.groups.add(group)
+
         update_basket_task.delay(profile.id)
 
     return redirect(reverse('group', args=[group.url]))

--- a/apps/phonebook/forms.py
+++ b/apps/phonebook/forms.py
@@ -14,6 +14,7 @@ from apps.users.models import User, UserProfile
 from models import Invite
 
 PAGINATION_LIMIT = 20
+PAGINATION_LIMIT_LARGE = 50
 REGEX_NUMERIC = re.compile('\d+', re.IGNORECASE)
 
 


### PR DESCRIPTION
I haven't added sorting options yet. Current sorting is done alphabetically using name of the groups. I'll add that soon, once I figure out how to use the members count as the "order_by" criteria.

Current screen looks like this:

![screenshot - thursday 23 may 2013 - 03 53 51 ist](https://f.cloud.github.com/assets/364832/551610/8aaaa068-c32e-11e2-97ec-1be00fc1d5a3.png)
