### PR TITLE
[Bug 886945] Translation fixes

### DIFF
--- a/apps/common/middleware.py
+++ b/apps/common/middleware.py
@@ -9,11 +9,12 @@ from django.http import HttpResponseRedirect
 from django.utils.encoding import iri_to_uri
 from django.shortcuts import redirect
 from tower import ugettext as _
+from tower import ugettext_lazy as _lazy
 
 from apps.groups.models import Group, GroupAlias
 
-LOGIN_MESSAGE = _('You must be logged in to continue.')
-GET_VOUCHED_MESSAGE = _('You must be vouched to continue.')
+LOGIN_MESSAGE = _lazy(u'You must be logged in to continue.')
+GET_VOUCHED_MESSAGE = _lazy(u'You must be vouched to continue.')
 
 
 class RegisterMiddleware(object):

--- a/apps/groups/forms.py
+++ b/apps/groups/forms.py
@@ -2,7 +2,7 @@ import re
 
 from django import forms
 
-from tower import ugettext_lazy as _
+from tower import ugettext_lazy as _lazy
 
 from helpers import stringify_groups
 from models import Group
@@ -11,15 +11,15 @@ from models import Group
 class SortForm(forms.Form):
     """Group Index Sort Form."""
     sort = forms.ChoiceField(required=False,
-                             choices=(('name', 'Group Name A-Z'),
-                                      ('-num_members', 'Most Members'),
-                                      ('num_members', 'Fewest Members')))
-
+                             choices=(('name', _lazy(u'Group Name A-Z')),
+                                      ('-num_members', _lazy(u'Most Members')),
+                                      ('num_members', _lazy(u'Fewest Members'))))
 
     def clean_sort(self):
         if self.cleaned_data['sort'] == '':
             return 'name'
         return self.cleaned_data['sort']
+
 
 class GroupWidget(forms.TextInput):
 

--- a/apps/groups/templates/groups/group.html
+++ b/apps/groups/templates/groups/group.html
@@ -114,7 +114,9 @@
     {% if not people.paginator.count %}
       <div class="well">
         <p id="not-found">
-          Sorry, we cannot find any mozillians in {{ group.name }}
+          {% trans group_name=group.name %}
+            Sorry, we cannot find any mozillians in {{ group_name }}
+          {% endtrans %}
         </p>
       </div>
     {% else %}

--- a/apps/groups/templates/groups/index.html
+++ b/apps/groups/templates/groups/index.html
@@ -9,7 +9,7 @@
     <div class="sort">
       <form method="get">
           {{ sort_form }}
-          <input type="submit" value="Sort" />
+          <input type="submit" value="{{ _('Sort') }}" />
       </form>
     </div>
     <p>

--- a/apps/phonebook/templates/phonebook/home.html
+++ b/apps/phonebook/templates/phonebook/home.html
@@ -62,8 +62,10 @@
           {% else %}
             <h2>3000+</h2>
             <p>
-              Passionate Mozillians you can meet for work, play or a
-              cup of coffee.
+              {% trans %}
+                Passionate Mozillians you can meet for work, play or a
+                cup of coffee.
+              {% endtrans %}
             </p>
           {% endif %}
         </section>

--- a/apps/users/templates/registration/register.html
+++ b/apps/users/templates/registration/register.html
@@ -13,7 +13,8 @@
   <div id="register" class="container">
     {% if (user_form.errors or profile_form.errors) %}
       <div class="alert alert-error">
-        The following fields are required (optin is the checkbox in the last panel):
+
+        {{ _('The following fields are required (optin is the checkbox in the last panel)') }}:
         <ol>
         {% for error in user_form.errors %}
           <li>{{ error|escape }}</li>
@@ -30,9 +31,11 @@
       {{ csrf() }}
       <h1>{{ _('Create Your Profile') }}</h1>
       <div class="alert alert-info">
-        Our community directory is for Mozillians who are 13 and
-        older. We take safety issues very seriously, especially with
-        minors. If you are under 13, please don't create an account.
+        {% trans %}
+          Our community directory is for Mozillians who are 13 and
+          older. We take safety issues very seriously, especially with
+          minors. If you are under 13, please don't create an account.
+        {% endtrans %}
       </div>
       <div class="tabbable">
         <ul class="nav nav-pills">


### PR DESCRIPTION
See [Bug 886945](https://bugzilla.mozilla.org/show_bug.cgi?id=886945) for reference.

There were a few items in there that looked like they should work fine or might be missing a translation in general:
- Text of invite email is in English; email text is wrapped in a {% trans %} tag and should work ok. Might be missing a translation.
- Editing profile, values of "Visible to:" are in English (Mozillians/Public); I remember from my notes that we were not wanting translation around these. Please verify.
- The template syntax shows that the text in `phonebook/invited.html` should be translated: https://github.com/juliaelman/mozillians/blob/26e65b9615b7cc7d8d5aa59015416aeaec3c8258/apps/phonebook/templates/phonebook/invited.html#L10 
