### PR TITLE
[Bug 886867] Fixing mosaic display overlap on Nexus 7.

### DIFF
--- a/media/css/main.less
+++ b/media/css/main.less
@@ -532,6 +532,12 @@ body#home {
                     overflow: hidden;
                 }
             }
+            @media (max-width: 1024px) {
+                ul { 
+                    max-height: 295px;
+                    overflow: hidden;
+                }
+            }
         }
 
         #main-feature {


### PR DESCRIPTION
See [Bug 886867](https://bugzilla.mozilla.org/show_bug.cgi?id=886867) for reference.
