### PR TITLE
[Fix Bug 895349] Adding padding to alert message at the bottom of create profile form.

### DIFF
--- a/apps/phonebook/templates/phonebook/edit_profile.html
+++ b/apps/phonebook/templates/phonebook/edit_profile.html
@@ -262,7 +262,7 @@
         </label>
       </fieldset>
 
-      <p class="alert-info">
+      <p class="alert alert-info">
         {% trans %}
           You will begin to receive email communications from Mozilla
           once you are a vouched Mozillian. You may unsubscribe at


### PR DESCRIPTION
See [Bug 895349](https://bugzilla.mozilla.org/show_bug.cgi?id=895349) for reference.
