### PR TITLE
[Fix Bug 895347] Fix alert messages from overlapping.

### DIFF
--- a/apps/phonebook/templates/phonebook/profile.html
+++ b/apps/phonebook/templates/phonebook/profile.html
@@ -14,7 +14,7 @@
       {% for message in messages %}
         {% with %}
           {% set label = message.tags in ['error', 'success', 'info'] %}
-          <div class="alert{% if label %} alert-{{ message.tags }}{% endif %} offset1 span8">{{ message }}</div>
+          <div class="alert{% if label %} alert-{{ message.tags }}{% endif %}">{{ message }}</div>
         {% endwith %}
       {% endfor %}
   {% endif %}


### PR DESCRIPTION
See [Bug 895347](https://bugzilla.mozilla.org/show_bug.cgi?id=895347) for reference.
