### PR TITLE
[Fix Bug 899891] Remove vouched messaging on create profile from for new users.

### DIFF
--- a/mozillians/phonebook/templates/phonebook/edit_profile.html
+++ b/mozillians/phonebook/templates/phonebook/edit_profile.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 
-{% block page_title %}{{ _('Edit Your Profile') }}{% endblock %}
+{% block page_title %}
+  {% if profile.is_complete %}
+    {{ _('Edit Your Profile') }}
+  {% else %}
+    {{ _('Create Your Profile') }}
+  {% endif %}
+{% endblock %}
 {% block body_id %}edit-profile{% endblock %}
 
 {% macro privacy_field(name, original_value) %}
@@ -263,79 +269,40 @@
       {% endif %}
     </fieldset>
 
-    <fieldset id="invites">
-      <legend>{{ _('Vouches & Invites') }}</legend>
-      <h5>{{ _('Vouched By') }}</h5>
-      {% if profile.vouched_by %}
-        <a href="{{ url('phonebook:profile_view', profile.vouched_by.user.username) }}" class="vouched">
-          {{ profile.vouched_by.display_name }}
-        </a>
-      {% elif profile.is_vouched %}
-        {{ _('You are automatically vouched!') }}
-      {% else %}
-        {% trans profile_url=absolutify(url('phonebook:profile_view', user.username)) %}
-          You aren't vouched! Send this link to a mozillian
-          who can vouch for your contributions:
-          <em class="underline" title="Your profile URL">
-            {{ profile_url }}
-          </em>
-        {% endtrans %}
-      {% endif %}
-      {% if my_vouches %}
-        <h5>{{ _('Vouchees') }}</h5>
-        <ul class="vouchees">
-          {% for vouchee in my_vouches %}
-            <li>
-              <a href="{{ url('phonebook:profile_view', vouchee.user.username) }}" class="vouched">
-                {{ vouchee.display_name }}
-              </a>
-            </li>
-          {% endfor %}
-        </ul>
-      {% endif %}
-
-      {# <div class="control-group">
-
-          <div class="controls">
-            <span class="label-text">
-              {% if profile.vouched_by %}
-                <a href="{{ url('phonebook:profile_view', profile.vouched_by.user.username) }}" class="vouched">
-                  {{ profile.vouched_by.display_name }}
-                </a>
-              {% elif profile.is_vouched %}
-                {{ _('You are automatically vouched!') }}
-              {% else %}
-                {% trans profile_url=absolutify(url('phonebook:profile_view', user.username)) %}
-                  You aren't vouched! Send this link to a mozillian
-                  who can vouch for your contributions:
-                  <em class="underline" title="Your profile URL">
-                    {{ profile_url }}
-                  </em>
-                {% endtrans %}
-              {% endif %}
-            </span>
-          </div>
-        </div>
-        {% if my_vouches %}
-        <hr>
-          <div class="control-group">
-            <label class="control-label">{{ _('Vouchees') }}</label>
-            <div class="controls">
-              <ul class="vouchees">
-                {% for vouchee in my_vouches %}
-                  <li class="label-text">
-                    <a href="{{ url('phonebook:profile_view', vouchee.user.username) }}" class="vouched">
-                      {{ vouchee.display_name }}
-                    </a>
-                  </li>
-                {% endfor %}
-              </ul>
-            </div>
-          </div>
+    {% if profile.is_complete %}
+      <fieldset id="invites">
+        <legend>{{ _('Vouches & Invites') }}</legend>
+        <h5>{{ _('Vouched By') }}</h5>
+        {% if profile.vouched_by %}
+          <a href="{{ url('phonebook:profile_view', profile.vouched_by.user.username) }}" class="vouched">
+            {{ profile.vouched_by.display_name }}
+          </a>
+        {% elif profile.is_vouched %}
+          {{ _('You are automatically vouched!') }}
+        {% else %}
+          {% trans profile_url=absolutify(url('phonebook:profile_view', user.username)) %}
+            You aren't vouched! Send this link to a mozillian
+            who can vouch for your contributions:
+            <em class="underline" title="Your profile URL">
+              {{ profile_url }}
+            </em>
+          {% endtrans %}
         {% endif %}
-      </div>
-    </div> #}
-    </fieldset>
+        {% if my_vouches %}
+          <h5>{{ _('Vouchees') }}</h5>
+          <ul class="vouchees">
+            {% for vouchee in my_vouches %}
+              <li>
+                <a href="{{ url('phonebook:profile_view', vouchee.user.username) }}" class="vouched">
+                  {{ vouchee.display_name }}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+
+      </fieldset>
+    {% endif %}
 
     {% if not profile.is_complete %}
       <fieldset id="privacy-verify">


### PR DESCRIPTION
See [Bug 899891](https://bugzilla.mozilla.org/show_bug.cgi?id=899891) for reference. I also added a conditional around the `<title>` so that it say "Create" instead of "Edit" when new users are creating their profile. 
