### PR TITLE
[Fix Bug 907658] Changing GROUPS_PER_PAGE setting to 20.

### DIFF
--- a/mozillians/groups/views.py
+++ b/mozillians/groups/views.py
@@ -17,7 +17,7 @@ from mozillians.phonebook import forms
 from mozillians.users.tasks import update_basket_task
 
 
-GROUPS_PER_PAGE = 1
+GROUPS_PER_PAGE = 20
 log = commonware.log.getLogger('m.groups')
 
 


### PR DESCRIPTION
See [Bug 907658](https://bugzilla.mozilla.org/show_bug.cgi?id=907658) for reference.

In the refactoring of `apps/groups/views.py` there was a new setting added called `GROUPS_PER_PAGE` which replaced `PAGINATION_LIMIT_LARGE`. Groups and functional areas list pages were only displaying one item, since that settings was set to that value.
