### PR TITLE
[Fix Bug 904758] Fixes search box placeholder text cut off and search on logged in homepage.

### DIFF
--- a/media/css/main.less
+++ b/media/css/main.less
@@ -118,9 +118,11 @@
 body {
     &.loggedin {
         #masthead {
-            @media (min-width: @breakMobileLandscape) and
-            (max-width: @breakTablet) {
+            @media (max-width: @breakTablet) {
                 padding-bottom: 0;
+            }
+            @media (max-width: @breakMobile) {
+                padding-bottom: 20px;
             }
         }
         #content-wrapper {
@@ -135,7 +137,7 @@ body {
         }
         #nav-main {
             @media (max-width: @breakTablet) {
-                float: none;
+                position: absolute;
                 i { font-size: 30px; }
                 span {
                     &.username { display: none; }
@@ -143,6 +145,18 @@ body {
                 }
             }
 
+        }
+        .brand {
+            @media (max-width: @breakTablet) {
+                margin-left: 40px;
+            }
+            @media (max-width: @breakMobileLandscape) {
+                margin-left: 35px;
+                img {
+                    padding: 5px 0 0 0;
+                    width: 100px;
+                }
+            }
         }
         &.old {
             #main {
@@ -458,9 +472,6 @@ nav {
                 right: 11px;
                 z-index: -100;
                 @media (max-width: @breakTablet) {
-                    right: 6px;
-                }
-                @media (max-width: @breakMobileLandscape) {
                     right: 100%;
                     left: 4px;
                 }
@@ -831,6 +842,12 @@ body#home {
         }
     }
     &.loggedin {
+        nav form.navbar-search {
+            display: none;
+            @media (max-width: @breakDesktop) {
+                display: inline;
+            }
+        }
         #main {
             #profile-info {
                 .span(3);
@@ -904,7 +921,7 @@ body#home {
                         color: lighten(@black,70%);
                     }
                     @media (max-width: @breakDesktop) {
-                            margin: 25px 0 0 0;
+                        display: none;
                     }
                 }
                 .announcements-mozfacts {
@@ -1597,12 +1614,15 @@ body#about {
 /* Invite/Invited
 ================== */
 body#invite {
-    .bump-button {
-        margin-bottom: 9px;
+    min-height: 500px;
+    button[type=submit] {
+        margin: 20px 0;
+        .button;
     }
-}
-body#invited, body#invite {
-    .old {
-        min-height: 500px;
+    textarea {
+        @media (max-width: @breakMobileLandscape) {
+            width: 80%;
+        }
     }
+    input { margin-bottom: 25px; }
 }

--- a/mozillians/phonebook/templates/phonebook/about.html
+++ b/mozillians/phonebook/templates/phonebook/about.html
@@ -1,62 +1,64 @@
-{% extends "base-old.html" %}
+{% extends "base.html" %}
 
 {% block page_title %}{{ _('About Mozillians') }}{% endblock %}
 {% block body_id %}about{% endblock %}
 
 {% block content %}
-  <img id="photo-collage" src="{{ MEDIA_URL }}img/about-photo-collage.png"
-       alt="{{ _('Photo collage of Mozillians') }}">
-    <h1>{{ _('About Mozillians') }}</h1>
-    {% trans wiki_roadmap_url='https://wiki.mozilla.org/Mozillians#Roadmap',
-             wiki_get_involved_url='https://wiki.mozilla.org/Mozillians#Get_Involved' %}
-      <p>
-        Mozillians are people who volunteer their time to advance the Mozilla
-        mission. They're dedicated to promoting openness, innovation and
-        opportunity on the Web and they form the core of our community.
-      </p>
-      <p>
-        This directory is a resource to make it easy for Mozillians to learn
-        who is involved, what they do and how to connect with them. It also
-        allows you to receive email communications from Mozilla.
-      </p>
-      <p>
-        Want to find Mozillians in Auckland for a meetup? Need an expert XPCOM
-        hacker to review a patch? That's exactly what this site is for.
-      </p>
-      <p>
-        <a href="{{ wiki_roadmap_url }}">These features</a>, and
-        others, are currently in development. If you'd like to help
-        us out with these, find out how you can <a href="{{
-        wiki_get_involved_url }}"> get involved</a>.
-      </p>
-    {% endtrans %}
-  <section id="privacy" class="key-info">
-    <h2>{{ _('Privacy First') }}</h2>
-    <p>
-      {% trans privacy_policy_url=('http://www.mozilla.org/'
-                                   + LANG +'/privacy-policy.html') %}
-        Privacy has been an important part of this directory from the very
-        beginning. We want to make sure we provide Mozillians with the best
-        experience possible, from the way the site is built to the way we
-        vouch for new users before they can access data that should only be
-        available to other Mozillians. Read our
-        <a href="{{ privacy_policy_url }}">
-          Privacy Policy
-        </a> for more information.
+  <div class="container">
+    <img id="photo-collage" src="{{ MEDIA_URL }}img/about-photo-collage.png"
+         alt="{{ _('Photo collage of Mozillians') }}">
+      <h1>{{ _('About Mozillians') }}</h1>
+      {% trans wiki_roadmap_url='https://wiki.mozilla.org/Mozillians#Roadmap',
+               wiki_get_involved_url='https://wiki.mozilla.org/Mozillians#Get_Involved' %}
+        <p>
+          Mozillians are people who volunteer their time to advance the Mozilla
+          mission. They're dedicated to promoting openness, innovation and
+          opportunity on the Web and they form the core of our community.
+        </p>
+        <p>
+          This directory is a resource to make it easy for Mozillians to learn
+          who is involved, what they do and how to connect with them. It also
+          allows you to receive email communications from Mozilla.
+        </p>
+        <p>
+          Want to find Mozillians in Auckland for a meetup? Need an expert XPCOM
+          hacker to review a patch? That's exactly what this site is for.
+        </p>
+        <p>
+          <a href="{{ wiki_roadmap_url }}">These features</a>, and
+          others, are currently in development. If you'd like to help
+          us out with these, find out how you can <a href="{{
+          wiki_get_involved_url }}"> get involved</a>.
+        </p>
       {% endtrans %}
-    </p>
-  </section>
-  <section id="get-involved" class="key-info">
-    <h2>{{ _('Get Involved') }}</h2>
-    <p>
-      {% trans google_groups_url='https://groups.google.com/forum/?fromgroups#!forum/mozilla.dev.community-tools' %}
-        The community directory is also a community project and you are
-        welcome to get involved to help us make it even better or to
-        integrate it into other community tools. Get in touch with us on the
-        <a href="{{ google_groups_url }}">
-          Mozillians forums
-        </a> to learn how.
-      {% endtrans %}
-    </p>
-  </section>
+    <section id="privacy" class="key-info">
+      <h2>{{ _('Privacy First') }}</h2>
+      <p>
+        {% trans privacy_policy_url=('http://www.mozilla.org/'
+                                     + LANG +'/privacy-policy.html') %}
+          Privacy has been an important part of this directory from the very
+          beginning. We want to make sure we provide Mozillians with the best
+          experience possible, from the way the site is built to the way we
+          vouch for new users before they can access data that should only be
+          available to other Mozillians. Read our
+          <a href="{{ privacy_policy_url }}">
+            Privacy Policy
+          </a> for more information.
+        {% endtrans %}
+      </p>
+    </section>
+    <section id="get-involved" class="key-info">
+      <h2>{{ _('Get Involved') }}</h2>
+      <p>
+        {% trans google_groups_url='https://groups.google.com/forum/?fromgroups#!forum/mozilla.dev.community-tools' %}
+          The community directory is also a community project and you are
+          welcome to get involved to help us make it even better or to
+          integrate it into other community tools. Get in touch with us on the
+          <a href="{{ google_groups_url }}">
+            Mozillians forums
+          </a> to learn how.
+        {% endtrans %}
+      </p>
+    </section>
+  </div>
 {% endblock %}

--- a/mozillians/phonebook/templates/phonebook/home.html
+++ b/mozillians/phonebook/templates/phonebook/home.html
@@ -9,7 +9,15 @@
 {% endif %}
 {% endblock mosaic %}
 
-{% block search %}{% endblock %}
+{% block search %}
+  {% if user.is_authenticated() %}
+    <form class="navbar-search"
+        action="{{ url('phonebook:search') }}" method="GET">
+      <input type="text" name="q" class="search-query"
+          placeholder="{{ _('Search for people, groups and more') }}">
+    </form>
+  {% endif %}
+{% endblock %}
 
 {% block content %}
   {% if not user.is_authenticated() %}

--- a/mozillians/phonebook/templates/phonebook/invite.html
+++ b/mozillians/phonebook/templates/phonebook/invite.html
@@ -1,9 +1,10 @@
-{% extends "base-old.html" %}
+{% extends "base.html" %}
 
 {% block page_title %}{{ _('Invite a Mozillian') }}{% endblock %}
 {% block body_id %}invite{% endblock %}
 
 {% block content %}
+
   <h1>{{ _('Invite a Mozillian') }}</h1>
 
   <p>
@@ -17,7 +18,7 @@
     {{ csrf() }}
     {{ bootstrap(invite_form.recipient) }}
     {{ bootstrap(invite_form.message) }}
-    <button type="submit" class="btn bump-button">
+    <button type="submit">
       {{ _('Send invite') }}
     </button>
     <p>


### PR DESCRIPTION
See the following comment for reference:
[https://bugzilla.mozilla.org/show_bug.cgi?id=904758#c11](https://bugzilla.mozilla.org/show_bug.cgi?id=904758#c11)

I also found the text cut-off on the about mozillians page, as it still uses the old base template and styles. You'll see that fix in this PR too.
