### PR TITLE
[fix bug 913375] Autofocus search boxes

### DIFF
--- a/mozillians/phonebook/templates/phonebook/home.html
+++ b/mozillians/phonebook/templates/phonebook/home.html
@@ -25,7 +25,7 @@
       <img id="mozillians-logo" src="{{ MEDIA_URL }}img/mozillians-logo.png" alt="Mozillians">
       <hr>
       <form id="homepage-search" action="{{ url('phonebook:search') }}" method="GET">
-          <input type="text" name="q" class="search-query"
+          <input autofocus type="text" name="q" class="search-query"
           placeholder="{{ _('Search for people, groups and more') }}">
        </form>
     </hgroup>
@@ -158,7 +158,7 @@
     <article id="content-info">
       <h1>{{ _('Hello!') }}</h1>
       <form id="homepage-search" action="{{ url('phonebook:search') }}" method="GET">
-        <input type="text" name="q" class="search-query"
+        <input autofocus type="text" name="q" class="search-query"
                placeholder="{{ _('Search for people, groups and more') }}">
         <small>{{ _('Examples:') }}
           {% trans search_url=url('phonebook:search') %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -67,7 +67,7 @@
                 {% block search %}
                   <form class="navbar-search"
                       action="{{ url('phonebook:search') }}" method="GET">
-                    <input type="text" name="q" class="search-query"
+                    <input autofocus type="text" name="q" class="search-query"
                         placeholder="{{ _('Search for people, groups and more') }}">
                   </form>
                 {% endblock %}


### PR DESCRIPTION
This autofocuses almost all search boxes in modern browsers, except the navbar search box on the homepage on small screens. To autofocus that search bar we'll have to make significant changes to markup/css; I'm not sure autofocus on small/touch screens is as important though.
