### PR TITLE
Removed the IRC link from the profile page. IRC name is still visible, i...

### DIFF
--- a/mozillians/groups/templates/groups/group.html
+++ b/mozillians/groups/templates/groups/group.html
@@ -40,9 +40,7 @@
                     {% endif %}
                     </span>
                     {% for irc in irc_channels %}
-                        <a href="irc://irc.mozilla.org/{{ irc }}">
-                        {{ irc }}
-                        </a>
+                      {{ irc }}
                     {% endfor %}
                   </li>
                 {% endif %}

--- a/mozillians/phonebook/templates/phonebook/profile.html
+++ b/mozillians/phonebook/templates/phonebook/profile.html
@@ -226,9 +226,7 @@
             {% if profile.ircname %}
               <li class="p-nickname">
                 <i class="icon-comments-alt"></i> IRC : 
-                <a href="irc://irc.mozilla.org/">
-                    <span class="nickname">{{ profile.ircname }}</span>
-                  </a>
+                <span class="nickname">{{ profile.ircname }}</span>
               </li>
             {% endif %}
             {% if profile.website %}


### PR DESCRIPTION
...t just doesn't link to anything anymore.

Bugzilla #845799
