### PR TITLE
[Fix Bug 933907] fix order of logout.html js files

### DIFF
--- a/mozillians/phonebook/templates/phonebook/logout.html
+++ b/mozillians/phonebook/templates/phonebook/logout.html
@@ -3,9 +3,11 @@
     <title>Logging out...</title>
       {% compress js %}
         <script src="{{ static('mozillians/js/libs/jquery-1.7.2.js') }}"></script>
-        <script src="{{ static('mozillians/js/logout_view.js') }}"></script>
       {% endcompress %}
       {{ browserid_js() }}
+      {% compress js %}
+        <script src="{{ static('mozillians/js/logout_view.js') }}"></script>
+      {% endcompress %}
   </head>
   <body>
     Logging you out...


### PR DESCRIPTION
The issue here was that logout_view.js must come after the browserid_js files. However, we can't compress "browserid_js()" nor can we compress an external file(include.js). It is possible to use the {% compress_js %} tags twice, but, this seems like a cleaner solution. According to the django_browserid docs, you can just output these two files manually instead of using browserid_js() if you want, so that's what I've done in this particular file.
