### PR TITLE
[Fix 934495] Move the messages block in the base template into

### DIFF
--- a/mozillians/phonebook/templates/phonebook/profile.html
+++ b/mozillians/phonebook/templates/phonebook/profile.html
@@ -9,17 +9,7 @@
   {% if not profile.is_vouched %}pending{% endif %}
 {% endblock %}
 
-{% block messages %}{% endblock %}
-
 {% block content %}
-  {% if messages %}
-      {% for message in messages %}
-        {% with %}
-          {% set label = message.tags in ['error', 'success', 'info'] %}
-          <div class="alert{% if label %} alert-{{ message.tags }}{% endif %}">{{ message }}</div>
-        {% endwith %}
-      {% endfor %}
-  {% endif %}
   <div class="alert">
     {% if user.username == shown_user.username %}
       {{ _('Your Profile') }}

--- a/templates/base.html
+++ b/templates/base.html
@@ -139,25 +139,22 @@
 
     {% block mosaic %}{% endblock %}
 
-    {% block messages %}
-      {% if messages %}
-        {% for message in messages %}
-          {% with %}
-            {% set label = message.tags in ['error', 'success', 'info'] %}
-              <div class="alert{% if label %} alert-{{ message.tags }}{% endif %}"
-                   id="pending-approval">
-                {{ message }}
-              </div>
-          {% endwith %}
-        {% endfor %}
-      {% endif %}
-    {% endblock messages %}
-
     {% block content_wrapper %}
       <div id="content-wrapper">
         <div id="main" class="container">
+          {% block messages %}
+            {% for message in messages %}
+              {% with label = message.tags in ['error', 'success', 'info', 'warning'] %}
+                <div class="alert {% if label %}alert-{{ message.tags }}{% endif %}">
+                  {{ message }}
+                </div>
+              {% endwith %}
+            {% endfor %}
+          {% endblock messages %}
           {% block content %}{% endblock %}
-          <a href="#" id="back-to-top"><img src="{{ static('mozillians/img/back-to-top-arrow.png') }}" alt="Back to top"></a>
+          <a href="#" id="back-to-top">
+            <img src="{{ static('mozillians/img/back-to-top-arrow.png') }}" alt="Back to top">
+          </a>
         </div>
       </div>
     {% endblock %}


### PR DESCRIPTION
content_wrapper block for better placement of the messages.
