### PR TITLE
Bug 920270 - Basket subscribe API not returning token anymore

### DIFF
--- a/mozillians/settings/base.py
+++ b/mozillians/settings/base.py
@@ -225,7 +225,8 @@ STATSD_CLIENT = 'django_statsd.clients.normal'
 if 'test' in sys.argv:
     BASKET_URL = 'http://127.0.0.1'
 else:
-    BASKET_URL = 'http://basket.mozilla.com'
+    # Basket requires SSL now for some calls
+    BASKET_URL = 'https://basket.mozilla.com'
 BASKET_NEWSLETTER = 'mozilla-phone'
 
 USER_AVATAR_DIR = 'uploads/userprofile'


### PR DESCRIPTION
The Basket API's subscribe call is going to stop returning the
token and become purely asynchronous. Don't expect the token in
the response, and adapt other code to query Basket for the token
later if we need it.
