### PR TITLE
Bug 877315 - count vouched members in admin

### DIFF
--- a/mozillians/groups/admin.py
+++ b/mozillians/groups/admin.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib import admin
 from django.contrib.admin import SimpleListFilter
 from django.contrib.admin.widgets import FilteredSelectMultiple
-from django.db.models import Count
+from django.db.models import Count, Sum
 
 import autocomplete_light
 
@@ -64,7 +64,7 @@ class GroupBaseAdmin(admin.ModelAdmin):
     """GroupBase Admin."""
     save_on_top = True
     search_fields = ['name', 'aliases__name', 'url', 'aliases__url']
-    list_display = ['name', 'member_count']
+    list_display = ['name', 'member_count', 'vouched_member_count']
     list_display_links = ['name']
     list_filter = [EmptyGroupFilter]
     readonly_fields = ['url']
@@ -77,13 +77,28 @@ class GroupBaseAdmin(admin.ModelAdmin):
         return super(GroupBaseAdmin, self).get_form(request, obj, **defaults)
 
     def queryset(self, request):
+        # The Sum('members__is_vouched') annotation only works for
+        # databases where the Boolean type is really an integer. It works
+        # for Sqlite3 or MySQL, but fails on Postgres. If Mozillians ever
+        # switches from MySQL to a database where this won't work, we'll
+        # need to revisit this.
         return (super(GroupBaseAdmin, self)
-                .queryset(request).annotate(member_count=Count('members')))
+                .queryset(request)
+                .annotate(member_count=Count('members'),
+                          vouched_member_count=Sum('members__is_vouched')))
 
     def member_count(self, obj):
         """Return number of members in group."""
         return obj.member_count
     member_count.admin_order_field = 'member_count'
+
+    def vouched_member_count(self, obj):
+        """Return number of vouched members in group"""
+        # Annotated field, could be None or a float
+        if obj.vouched_member_count:
+            return int(obj.vouched_member_count)
+        return 0
+    vouched_member_count.admin_order_field = 'vouched_member_count'
 
 
 class GroupAliasInline(admin.StackedInline):
@@ -110,7 +125,7 @@ class GroupAdmin(GroupBaseAdmin):
                                                     form=GroupAddAdminForm)
     inlines = [GroupAliasInline]
     list_display = ['name', 'steward', 'wiki', 'website', 'irc_channel',
-                    'member_count']
+                    'member_count', 'vouched_member_count']
     list_filter = [CurratedGroupFilter, EmptyGroupFilter]
 
 

--- a/mozillians/groups/tests/test_admin.py
+++ b/mozillians/groups/tests/test_admin.py
@@ -1,0 +1,40 @@
+from django.contrib.admin.sites import site
+from django.http import HttpRequest
+
+from mock import Mock
+from nose.tools import eq_, ok_
+
+from mozillians.common.tests import TestCase
+from mozillians.groups.admin import GroupAdmin
+from mozillians.groups.models import Group
+from mozillians.groups.tests import GroupFactory
+from mozillians.users.tests import UserFactory
+
+
+class TestGroupAdmin(TestCase):
+    def test_member_counts(self):
+        # The Group admin computes how many vouched members there are
+        # and how many overall
+
+        # IMPORTANT: This test is expected to fail on Postgres, and
+        # probably other databases where the Boolean type is not just
+        # an alias for a small integer. Mozillians is currently
+        # deployed on a database where this works. If we ever try
+        # deploying it on another database where it doesn't work, this
+        # test will alert us quickly that we'll need to take another
+        # approach to this feature.
+
+        # Create group with 1 vouched member and 1 unvouched member
+        group = GroupFactory()
+        user = UserFactory(userprofile={'is_vouched': False})
+        group.members.add(user.userprofile)
+        user2 = UserFactory(userprofile={'is_vouched': True})
+        group.members.add(user2.userprofile)
+
+        admin = GroupAdmin(model=Group, admin_site=site)
+        mock_request = Mock(spec=HttpRequest)
+        qset = admin.queryset(mock_request)
+
+        g = qset.get(name=group.name)
+        eq_(2, g.member_count)
+        eq_(1, g.vouched_member_count)


### PR DESCRIPTION
In the admin list for groups, add a column to display the number of
vouched members, similar to the current column that counts all
members.

This implementation relies on the database implementing Booleans
as integers, so we can Sum() them. It works for MySQL, which is
how Mozillians is currently deployed.

A test is added that will fail if we ever try to use Mozillians
with a database where this doesn't work, which will alert us to
find another approach.
