### PR TITLE
Fix bug 942348: Correct GitHub capitalization.

### DIFF
--- a/mozillians/humans/templates/humans/humans.txt
+++ b/mozillians/humans/templates/humans/humans.txt
@@ -5,7 +5,7 @@ Mozillians.org
   GitHub Repo: https://github.com/mozilla/mozillians
 
 
-Contributors on Github
+Contributors on GitHub
 ----------------------
 
 {% for contributor in githubbers|sort %}

--- a/mozillians/users/models.py
+++ b/mozillians/users/models.py
@@ -628,7 +628,7 @@ class ExternalAccount(models.Model):
                    'url': 'https://addons.mozilla.org/user/{identifier}/'},
         TYPE_BMO: {'name': 'Bugzilla (BMO)',
                    'url': 'https://bugzilla.mozilla.org/user_profile?login={identifier}'},
-        TYPE_GITHUB: {'name': 'Github', 'url': 'https://github.com/{identifier}'},
+        TYPE_GITHUB: {'name': 'GitHub', 'url': 'https://github.com/{identifier}'},
         TYPE_MDN: {'name': 'MDN', 'url': 'https://developer.mozilla.org/profiles/{identifier}'},
         TYPE_SUMO: {'name': 'Mozilla Support', 'url': ''},
         TYPE_FACEBOOK: {'name': 'Facebook', 'url': 'https://www.facebook.com/{identifier}'},


### PR DESCRIPTION
I did not set up an instance to test this, so it might be best to give it a quick spot-check.
