### PR TITLE
[Bug 699530] Sanitizer now drops tables that we don't want to copy to dev/stage

### DIFF
--- a/scripts/mysql-anonymize/anonymize.py
+++ b/scripts/mysql-anonymize/anonymize.py
@@ -13,6 +13,13 @@ import random
 log = logging.getLogger('anonymize')
 common_hash_secret = '%016x' % (random.getrandbits(128))
 
+def get_drops(config):
+    database = config.get('database', {})
+    drops = database.get('drop', [])
+    sql = []
+    for drop in drops:
+        sql.append('DROP %s IF EXISTS' % drop)
+    return sql
 
 def get_truncates(config):
     database = config.get('database', {})
@@ -97,6 +104,7 @@ def anonymize(config):
     print 'SET FOREIGN_KEY_CHECKS=0;'
 
     sql = []
+    sql.extend(get_drops(config))
     sql.extend(get_truncates(config))
     sql.extend(get_deletes(config))
     sql.extend(get_updates(config))

--- a/scripts/mysql-anonymize/anonymize_dev.yml
+++ b/scripts/mysql-anonymize/anonymize_dev.yml
@@ -1,6 +1,26 @@
 databases:
     sanitize_dev_mozillians_org:
 
+        drop:
+            - api_apiapp
+            - celery_taskmeta
+            - celery_tasksetmeta
+            - django_admin_log
+            - django_session
+            - djcelery_crontabschedule
+            - djcelery_intervalschedule
+            - djcelery_periodictask
+            - djcelery_periodictasks
+            - djcelery_taskstate
+            - djcelery_workerstate
+            - schema_migration
+            - south_migrationhistory
+            - taskboard_task
+            - taskboard_task_groups
+            - tastypie_apiaccess
+            - tastypie_apikey
+            - thumbnail_kvstore
+
         tables:
             auth_user:
                 nullify:
@@ -28,4 +48,4 @@ databases:
 
             users_externalaccount:
                 random_username:
-                    - username
+                    - identifier

--- a/scripts/mysql-anonymize/anonymize_stage.yml
+++ b/scripts/mysql-anonymize/anonymize_stage.yml
@@ -1,6 +1,26 @@
 databases:
     sanitize_stage_mozillians_org:
 
+        drop:
+            - api_apiapp
+            - celery_taskmeta
+            - celery_tasksetmeta
+            - django_admin_log
+            - django_session
+            - djcelery_crontabschedule
+            - djcelery_intervalschedule
+            - djcelery_periodictask
+            - djcelery_periodictasks
+            - djcelery_taskstate
+            - djcelery_workerstate
+            - schema_migration
+            - south_migrationhistory
+            - taskboard_task
+            - taskboard_task_groups
+            - tastypie_apiaccess
+            - tastypie_apikey
+            - thumbnail_kvstore
+
         tables:
             auth_user:
                 random_email_noadmin:


### PR DESCRIPTION
This is to handle the tables we don't want to copy over because they contain metadata that might mess things up in stage/dev environments.

I'm not sure what some of these tables are even used for, maybe some of them need to go away permanently? Like I don't think we're even using database sessions, so django_session probably should go away... and I don't know what the taskboard_\* tables are for...
