### PR TITLE
[Bug 940941] Show helpful message if searching logged out

### DIFF
--- a/mozillians/templates/phonebook/search.html
+++ b/mozillians/templates/phonebook/search.html
@@ -12,6 +12,20 @@
 {% block search %}{% endblock %}
 
 {% block content %}
+  {% if not user.is_authenticated() or not user.userprofile.is_vouched %}
+    <p class="alert">
+      {{ _('You are currently searching public profiles.') }}
+      {% if not user.is_authenticated() %}
+        {% trans next=request.get_full_path(), title=_('Sign In') %}
+          View more results by
+          <a href="#" class="browserid-login" title="{{ title }}" data-next="{{ next }}">
+            logging in</a>.
+        {% endtrans %}
+      {% else %}
+        {{ _('View more results when vouched.') }}
+      {% endif %}
+    </p>
+  {% endif %}
   <h1>{{ _('Search') }}</h1>
   <form method="GET" id="search-form" action="{{ url('phonebook:search') }}">
     {{ field_with_attrs(search_form.q,


### PR DESCRIPTION
First go at fixing this issue: https://bugzilla.mozilla.org/show_bug.cgi?id=940941

Just checking in the template if the user is logged in when searching and if not we display a helpful message and give them a link to login. Let me know if there is anything I should change!
