### PR TITLE
[bug 699530] Remove taskboard_* tables.

### DIFF
--- a/scripts/mysql-anonymize/anonymize_dev.yml
+++ b/scripts/mysql-anonymize/anonymize_dev.yml
@@ -15,8 +15,6 @@ databases:
             - djcelery_workerstate
             - schema_migration
             - south_migrationhistory
-            - taskboard_task
-            - taskboard_task_groups
             - tastypie_apiaccess
             - tastypie_apikey
             - thumbnail_kvstore

--- a/scripts/mysql-anonymize/anonymize_stage.yml
+++ b/scripts/mysql-anonymize/anonymize_stage.yml
@@ -15,8 +15,6 @@ databases:
             - djcelery_workerstate
             - schema_migration
             - south_migrationhistory
-            - taskboard_task
-            - taskboard_task_groups
             - tastypie_apiaccess
             - tastypie_apikey
             - thumbnail_kvstore


### PR DESCRIPTION
taskboard_\* tables are leftovers of now removed code. We removed them
from our database, so now we can remove them from this script as well.
