### PR TITLE
[Bug 948166] make basket_token editable in admin panel

### DIFF
--- a/mozillians/users/admin.py
+++ b/mozillians/users/admin.py
@@ -198,7 +198,7 @@ class LastLoginFilter(SimpleListFilter):
 class UserProfileInline(AdminImageMixin, admin.StackedInline):
     """UserProfile Inline model for UserAdmin."""
     model = UserProfile
-    readonly_fields = ['date_vouched', 'vouched_by', 'basket_token']
+    readonly_fields = ['date_vouched', 'vouched_by']
     form = autocomplete_light.modelform_factory(UserProfile)
 
 


### PR DESCRIPTION
Being able to clear and change the token would be useful for debugging ExactTarget issues, and it doesn't seem harmful to allow clearing this. It's pretty unlikely to happen by accident given the position of this field in the panel!
