### PR TITLE
Don't compress dynamic form media elements.

### DIFF
--- a/mozillians/templates/phonebook/edit_profile.html
+++ b/mozillians/templates/phonebook/edit_profile.html
@@ -11,9 +11,9 @@
 
 {% block extrahead %}
   {% compress css %}
-    {{ profile_form.media.css }}
     <link href="{{ static('mozillians/css/profile_edit.less') }}" type="text/less" rel="stylesheet" media="screen" />
   {% endcompress %}
+  {{ profile_form.media.css }}
 {% endblock extrahead %}
 
 {% block content %}
@@ -450,6 +450,6 @@
     <script src="{{ static('mozillians/js/libs/tag-it/js/tag-it.js') }}"></script>
     <script src="{{ static('mozillians/js/profile_edit.js') }}"></script>
     <script src="{{ static('mozillians/js/tag-it-groups.js') }}"></script>
-    {{ profile_form.media.js }}
   {% endcompress %}
+  {{ profile_form.media.js }}
 {% endblock %}


### PR DESCRIPTION
Since we're using jingo_compress to precompress your static files, we
cannot point to dynamic variables in our compress blocks. Moving those
outside compress.
