### PR TITLE
Bug 948640 - Group page member counts wrong

### DIFF
--- a/mozillians/groups/models.py
+++ b/mozillians/groups/models.py
@@ -123,15 +123,19 @@ class Group(GroupBase):
             num_members=models.Count('members'))
 
     @classmethod
-    def get_non_functional_areas(cls):
-        """Return all visible groups that are not functional areas."""
-        return cls.objects.filter(functional_area=False, visible=True).annotate(
+    def get_non_functional_areas(cls, **kwargs):
+        """
+        Return all visible groups that are not functional areas.
+
+        Use kwargs to apply additional filtering to the groups.
+        """
+        return cls.objects.filter(functional_area=False, visible=True, **kwargs).annotate(
             num_members=models.Count('members'))
 
     @classmethod
     def get_curated(cls):
         """Return all non-functional areas that are curated."""
-        return cls.get_non_functional_areas().filter(curator__isnull=False)
+        return cls.get_non_functional_areas(curator__isnull=False)
 
     @classmethod
     def search(cls, query):

--- a/mozillians/groups/tests/test_views.py
+++ b/mozillians/groups/tests/test_views.py
@@ -100,10 +100,12 @@ class IndexTests(TestCase):
     def test_index(self):
         user_1 = UserFactory.create(userprofile={'is_vouched': True})
         user_2 = UserFactory.create()
+        user_3 = UserFactory.create(userprofile={'is_vouched': True})
         group_1 = GroupFactory.create()
         group_2 = GroupFactory.create()
         group_3 = GroupFactory.create()
         group_1.members.add(user_1.userprofile)
+        group_1.members.add(user_3.userprofile)
         group_2.members.add(user_1.userprofile)
         group_3.members.add(user_2.userprofile)
 
@@ -113,6 +115,10 @@ class IndexTests(TestCase):
         self.assertTemplateUsed(response, 'groups/index_groups.html')
         eq_(set(response.context['groups'].paginator.object_list),
             set([group_1, group_2]))
+
+        # Member counts
+        group1 = response.context['groups'].paginator.object_list.get(pk=group_1.pk)
+        eq_(group1.num_members, 2)
 
     @requires_login()
     def test_index_anonymous(self):

--- a/mozillians/groups/views.py
+++ b/mozillians/groups/views.py
@@ -48,7 +48,7 @@ def index_groups(request):
     """Lists all public groups (in use) on Mozillians."""
     # Omit functional areas, invisible groups, and groups with
     # no vouched members
-    query = Group.get_non_functional_areas().filter(members__is_vouched=True)
+    query = Group.get_non_functional_areas(members__is_vouched=True)
     template = 'groups/index_groups.html'
     return _list_groups(request, template, query)
 


### PR DESCRIPTION
Fix bug 948640 - on the group list page, member counts were inflated.
