### PR TITLE
Bug 938680 - Don't show "Remove X" button for yourself

### DIFF
--- a/mozillians/templates/phonebook/includes/search_result.html
+++ b/mozillians/templates/phonebook/includes/search_result.html
@@ -1,5 +1,5 @@
 <div class="result">
-  {% if group and (is_curator or request.user.is_superuser) %}
+  {% if group and (is_curator or request.user.is_superuser) and (request.user != profile.user) %}
     <form action="{{ url('groups:remove_member', group_pk=group.pk, user_pk=profile.pk) }}" method="GET">
       {{ csrf() }}
       <button type="submit" class="button remove">{{ _('Remove') }} <span>✖</span></button>


### PR DESCRIPTION
When a curator is viewing a group, the group members are shown
withe a "Remove X" button that lets the curator remove the user
from the group. Curators should not be able to remove themselves
from the groups they curate, though. So don't show a "Remove X"
button on a user's own member card when the user is a curator
viewing a group they curate.
