### PR TITLE
DNM - Fix bug 963097 - Minimize pip-installed packages

### DIFF
--- a/docs/installation-virtualenv.rst
+++ b/docs/installation-virtualenv.rst
@@ -48,7 +48,7 @@ When you want to start contributing...
 
 #. Install development and compiled requirements::
 
-     (venv)$ pip install -r requirements/compiled.txt -r requirements/dev.txt
+     (venv)$ pip install -r requirements/dev.txt
      (lots more output - be patient again...)
      (venv) $
 

--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -1,3 +1,8 @@
+# This file has only packages that must be compiled natively during installation.
+# Everything else should either be in vendor or vendor-local, if it's needed in
+# production, or in dev.txt, if it's only needed for running tests or building
+# documentation.
+
 -r ../vendor/src/funfactory/funfactory/requirements/compiled.txt
 
 # Images

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,28 +1,15 @@
-# This file pulls in everything a developer needs. If it's a basic package
-# needed to run the site, it belongs in requirements/prod.txt. If it's a
-# package for developers (testing, docs, etc.), it goes in this file.
+# This file pulls in everything a developer needs that's not already in
+# vendor or vendor-local.
 
--r prod.txt
+# Things that can't be put into vendor or vendor-local because they build
+# platform-specific libraries:
+-r compiled.txt
 
-# Documentation
-Sphinx==1.1.3
-
-# Testing
+# Things that aren't in vendor or vendor-local because they're only needed to
+# run tests, not for production:
+factory-boy==2.3.0
 flake8==2.1.0
-nose==1.0.0
 mock==0.8.0
--e git://github.com/jbalogh/django-nose.git#egg=django_nose
--e git://github.com/jbalogh/test-utils.git#egg=test-utils
-lxml==2.1
-pyquery
 
-# L10n
-translate-toolkit==1.8.0
-
-# Debug tools
-django-extensions
-Werkzeug
-
-coverage
-nosenicedots
-factory-boy
+# Just for building documentation
+Sphinx==1.1.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,7 +1,0 @@
--r ../vendor/src/funfactory/funfactory/requirements/prod.txt
-
-BeautifulSoup<4.0
-django-selectable==0.7.0
-python-memcached==1.45
-unidecode
-urllib3


### PR DESCRIPTION
NOT READY TO MERGE

Looking for feedback on cleaning out a bunch of redundancies
in our requirements files.

Don't install a bunch of other stuff, that might hide problems
during development. If the code depends on some package that's
not in vendor, vendor-local, or requirements/compiled.txt, we
want to find out about it sooner rather than later.

It turned out that nothing in requirements/prod.txt was needed
at all - everything was already in vendor or vendor-local.

Incidentally I cleaned up bin/jenkins.sh a little so I could run it locally,
to verify that I had all the packages that Jenkins would need for testing,
and I removed some .pyc files that had been checked into vendor-local.
I can split those changes into other branches if requested.
