### PR TITLE
Bug 950242 - Admin management of group membership

### DIFF
--- a/mozillians/groups/admin.py
+++ b/mozillians/groups/admin.py
@@ -150,12 +150,17 @@ class GroupEditAdminForm(GroupBaseEditAdminForm):
         model = Group
 
 
+class GroupMemberInline(admin.TabularInline):
+    model = GroupMembership
+    form = autocomplete_light.modelform_factory(GroupMembership)
+
+
 class GroupAdmin(GroupBaseAdmin):
     """Group Admin."""
     form = autocomplete_light.modelform_factory(Group, form=GroupEditAdminForm)
     add_form = autocomplete_light.modelform_factory(Group,
                                                     form=GroupAddAdminForm)
-    inlines = [GroupAliasInline]
+    inlines = [GroupAliasInline, GroupMemberInline]
     list_display = ['name', 'curator', 'wiki', 'website', 'irc_channel',
                     'functional_area', 'accepting_new_members', 'members_can_leave', 'visible',
                     'member_count', 'vouched_member_count']
@@ -164,6 +169,12 @@ class GroupAdmin(GroupBaseAdmin):
 
 class GroupMembershipAdmin(admin.ModelAdmin):
     list_display = ['group', 'userprofile']
+    search_fields = ['group__name', 'group__url', 'group__description',
+                     'group__aliases__name', 'group__aliases__url',
+                     'userprofile__full_name', 'userprofile__ircname',
+                     'userprofile__region', 'userprofile__city', 'userprofile__country',
+                     'userprofile__user__username', 'userprofile__user__email'
+                     ]
 
 
 class SkillAliasInline(admin.StackedInline):


### PR DESCRIPTION
Allow Django admins to manage group members as inlines on the group's
admin page.

This will work fine for reasonable-sized groups, but will get unwieldy
when groups get really large.  We might be better off managing group
membership from a user's page, since a user is unlikely to belong to
so many groups that that would get too big. Unfortunately, Django currently
doesn't support nested inlines in the admin, which would be required
because we already implement the user admin by making the userprofile
an inline on the user page, and the membership would have to be an
inline on the userprofile.

A better way for admins to manage memberships might be directly in
the GroupMembership model. To make that easier, I've added a search
field to that admin changelist page that searches on a bunch of fields
in the groups and users associated with the membership records. It
shouldn't be hard to find a user's memberships or membership in a
group, or just add a new membership.

Fixes bug 950242
