### PR TITLE
Fix bug 938005 - Display current time in profile user's timezone

### DIFF
--- a/mozillians/common/tests/__init__.py
+++ b/mozillians/common/tests/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from contextlib import contextmanager, nested
 
 from django.contrib.auth.decorators import login_required

--- a/mozillians/common/tests/test_utils.py
+++ b/mozillians/common/tests/test_utils.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+
+from mock import patch
+from nose.tools import ok_, eq_
+from pytz import utc
+
+from django.test.utils import override_settings
+from django.utils.timezone import is_aware
+
+from mozillians.common.tests import TestCase
+from mozillians.common.utils import aware_utcnow, now_in_timezone, offset_of_timezone
+
+
+class TestAwareUTCNow(TestCase):
+    @override_settings(USE_TZ=False)
+    def test_aware_now_if_use_tz_false(self):
+        # aware_utcnow returns an aware time, even if USE_TZ is False
+        ok_(is_aware(aware_utcnow()))
+
+    @override_settings(USE_TZ=True)
+    def test_aware_now_if_use_tz_true(self):
+        # aware_utcnow returns an aware time, even if USE_TZ is True
+        ok_(is_aware(aware_utcnow()))
+
+
+class TestNowInTimezone(TestCase):
+    def test_now_in_timezone(self):
+        # now_in_timezone returns the current time, expressed in the desired timezone
+        # Construct a time in UTC that will be "now"
+        utc_time = datetime(1972, 1, 1, 12, 4, 5).replace(tzinfo=utc)
+        tz_name = "US/Eastern"  # 5 hours difference from UTC on 1/1/1972
+        with patch('mozillians.common.utils.aware_utcnow') as mock_aware_now:
+            mock_aware_now.return_value = utc_time
+            result = now_in_timezone(tz_name)
+        ok_(is_aware(result))
+        fmt_time = result.strftime("%H:%M %Z")
+        eq_('07:04 EST', fmt_time)
+
+
+class TestOffsetOfTimezone(TestCase):
+    def test_offset_of_timezone(self):
+        # offset_of_timezone returns the offset in minutes of the named timezone as of now
+        # Construct a time in UTC that will be "now"
+        utc_time = datetime(1972, 1, 1, 3, 4, 5).replace(tzinfo=utc)
+        tz_name = "US/Eastern"  # 5 hours difference from UTC on 1/1/1972
+        with patch('mozillians.common.utils.aware_utcnow') as mock_aware_now:
+            mock_aware_now.return_value = utc_time
+            result = offset_of_timezone(tz_name)
+        eq_(-300, result)

--- a/mozillians/common/utils.py
+++ b/mozillians/common/utils.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from pytz import timezone, utc
+
+
+def aware_utcnow():
+    """
+    Return timezone-aware now, same way Django does it, but regardless
+    of settings.USE_TZ. (This is a separate method so it can be easily
+    mocked to test the other methods.)
+    """
+    return datetime.utcnow().replace(tzinfo=utc)
+
+
+def now_in_timezone(timezone_name):
+    """
+    Return the current time, expressed in the named timezone
+    """
+    zone = timezone(timezone_name)
+    return zone.normalize(aware_utcnow().astimezone(zone))
+
+
+def offset_of_timezone(timezone_name):
+    """
+    Return offset from UTC of named time zone, in minutes, as of now.
+
+    This is (time in specified time zone) - (time UTC), so if the time
+    zone is 5 hours ahead of UTC, it returns 300.
+    """
+    now = now_in_timezone(timezone_name)
+    offset = now.tzinfo.utcoffset(now)  # timedelta
+    minutes = offset.seconds / 60 + offset.days * 24 * 60
+    return minutes

--- a/mozillians/static/mozillians/js/profile_view.js
+++ b/mozillians/static/mozillians/js/profile_view.js
@@ -2,4 +2,26 @@ $(document).ready(function() {
     $("#view-privacy-mode").change(function() {
         window.location = this.value;
     });
+
+    /* If we know the offset of the profile's time zone, add a tooltip */
+    var $section = $("section#timezone");
+    if ($section) {
+      var offset = $section.attr("data-timezone-offset");  /* in minutes */
+      if (offset !== "notset") {
+        /* get the browser's current timezone offset in minutes */
+        /* javascript gives it in the opposite direction we're expecting, so negate it */
+        var browser_offset = -(new Date()).getTimezoneOffset();
+        var diff = (offset - browser_offset) / 60;  /* convert from minutes to hours */
+        var msg_template;
+        if (diff > 0) {
+          msg_template = $("span#hours_ahead_text").text();
+        } else if (diff < 0) {
+          diff = -diff;
+          msg_template = $("span#hours_behind_text").text();
+        } else {
+          msg_template = $("span#same_timezone_text").text();
+        }
+        $section.attr("title", msg_template.replace("%HOURS%", diff));
+      }
+    }
 });

--- a/mozillians/templates/phonebook/profile.html
+++ b/mozillians/templates/phonebook/profile.html
@@ -100,8 +100,10 @@
           </section>
         {% endif %}
         {% if profile.timezone %}
-          <section id="timezone">
-            <i class="icon-time"></i> {{ profile.timezone }}
+          <section id="timezone" data-timezone-offset="{{ profile.timezone_offset()|default('notset') }}">
+            <i class="icon-time"></i>
+            {{ now_in_timezone(profile.timezone).strftime('%H:%M') }}
+            {{ profile.timezone }}
           </section>
         {% endif %}
        </div>
@@ -246,6 +248,16 @@
     </article>
     <span class="hidden category">Mozillians</span>
   </div>
+  {# strings that need translating, used from profile_view.js, replacing %HOURS% #}
+  <span class="hidden" id="hours_ahead_text">
+    {%- trans hours="%HOURS%" %}{{ hours }} hours ahead of your timezone{% endtrans -%}
+  </span>
+  <span class="hidden" id="hours_behind_text">
+    {%- trans hours="%HOURS%" %}{{ hours }} hours behind your timezone{% endtrans -%}
+  </span>
+  <span class="hidden" id="same_timezone_text">
+    {%- trans %}same time zone as yours{% endtrans -%}
+  </span>
 {% endblock %}
 
 {% block page_js %}

--- a/mozillians/users/models.py
+++ b/mozillians/users/models.py
@@ -22,6 +22,7 @@ from south.modelsinspector import add_introspection_rules
 from tower import ugettext as _, ugettext_lazy as _lazy
 
 from mozillians.common.helpers import gravatar
+from mozillians.common.utils import offset_of_timezone
 from mozillians.groups.models import (Group, GroupAlias, GroupMembership,
                                       Language, LanguageAlias,
                                       Skill, SkillAlias)
@@ -559,6 +560,15 @@ class UserProfile(UserProfilePrivacyModel, SearchMixin):
             group.pending = (membership.status == GroupMembership.PENDING)
             groups.append(group)
         return groups
+
+    def timezone_offset(self):
+        """
+        Return minutes the user's timezone is offset from UTC.  E.g. if user is
+        4 hours behind UTC, returns -240.
+        If user has not set a timezone, returns None (not 0).
+        """
+        if self.timezone:
+            return offset_of_timezone(self.timezone)
 
     def save(self, *args, **kwargs):
         self._privacy_level = None


### PR DESCRIPTION
When displaying a user's profile, show the current time in their timezone.

If the logged-in user's timezone is different from the profiled user, provide a tooltip that tells how many hours ahead or behind the profiled user's timezone is from the logged-in user's.

Bug 938005 comment 2 suggested that we could get the current user's timezone from the browser even if they're not logged in or have not set a timezone in their profile, but it wasn't clear to me how we could do that without a bit of inline javascript in our template, which the mozillians.org security settings won't execute.
