### PR TITLE
Focus on search when S key is pressed. - Bug 957994

### DIFF
--- a/mozillians/static/mozillians/js/main.js
+++ b/mozillians/static/mozillians/js/main.js
@@ -58,5 +58,12 @@ var app = {
         });
 
         $('input, textarea').placeholder(); 
+
+	// Focus search when S key is pressed
+	$('body').keypress(function(event){
+	  if (event.which==115 && !$('input, textarea, select').is(':focus')) {
+	    $('.search-query').focus(); 
+	  } 
+	});
     });
 })(jQuery);


### PR DESCRIPTION
I have ensured that this does not happen when the user is focused on form fields.
