### PR TITLE
[Fix bug 969063][Fix bug 968988] Fix group membership admin for unvouche...

### DIFF
--- a/mozillians/groups/admin.py
+++ b/mozillians/groups/admin.py
@@ -150,9 +150,20 @@ class GroupEditAdminForm(GroupBaseEditAdminForm):
         model = Group
 
 
-class GroupMemberInline(admin.TabularInline):
+class GroupMembershipAdminForm(forms.ModelForm):
+
+    class Meta:
+        model = GroupMembership
+        widgets = {
+            # Use autocomplete_light to allow any user profile.
+            'userprofile': autocomplete_light.ChoiceWidget('UserProfiles'),
+            'group': autocomplete_light.ChoiceWidget('Groups'),
+        }
+
+
+class GroupMembershipInline(admin.TabularInline):
     model = GroupMembership
-    form = autocomplete_light.modelform_factory(GroupMembership)
+    form = GroupMembershipAdminForm
 
 
 class GroupAdmin(GroupBaseAdmin):
@@ -160,7 +171,7 @@ class GroupAdmin(GroupBaseAdmin):
     form = autocomplete_light.modelform_factory(Group, form=GroupEditAdminForm)
     add_form = autocomplete_light.modelform_factory(Group,
                                                     form=GroupAddAdminForm)
-    inlines = [GroupAliasInline, GroupMemberInline]
+    inlines = [GroupAliasInline, GroupMembershipInline]
     list_display = ['name', 'curator', 'wiki', 'website', 'irc_channel',
                     'functional_area', 'accepting_new_members', 'members_can_leave', 'visible',
                     'member_count', 'vouched_member_count']
@@ -175,7 +186,7 @@ class GroupMembershipAdmin(admin.ModelAdmin):
                      'userprofile__region', 'userprofile__city', 'userprofile__country',
                      'userprofile__user__username', 'userprofile__user__email'
                      ]
-    form = autocomplete_light.modelform_factory(GroupMembership)
+    form = GroupMembershipAdminForm
 
 
 class SkillAliasInline(admin.StackedInline):

--- a/mozillians/users/autocomplete_light_registry.py
+++ b/mozillians/users/autocomplete_light_registry.py
@@ -5,7 +5,18 @@ import autocomplete_light
 from mozillians.users.models import UserProfile
 
 
+class UserProfileAutocomplete(autocomplete_light.AutocompleteModelBase):
+    """Any user profile"""
+    search_fields = ['full_name', 'user__email', 'user__username']
+    choices = UserProfile.objects.all()
+
+
+autocomplete_light.register(UserProfile, UserProfileAutocomplete,
+                            name='UserProfiles')
+
+
 class VouchedUserProfileAutocomplete(autocomplete_light.AutocompleteModelBase):
+    """Only vouched user profiles"""
     search_fields = ['full_name', 'user__email', 'user__username']
     choices = UserProfile.objects.vouched()
 
@@ -15,6 +26,7 @@ autocomplete_light.register(UserProfile, VouchedUserProfileAutocomplete,
 
 
 class VouchedUserAutocomplete(autocomplete_light.AutocompleteModelBase):
+    """Vouched users"""
     search_fields = ['userprofile__full_name', 'email']
     choices = (User.objects.exclude(userprofile__full_name='')
                .filter(userprofile__is_vouched=True))


### PR DESCRIPTION
autocomplete_light was raising validation errors because its
autocomplete field for members on the groupmembership model
was limited to vouched members but some groups have unvouched
members.

Modified the admin for group memberships to use an autocomplete
field that accepts any user profile.
