### PR TITLE
[fix bug 969098] Mark announcement text safe.

### DIFF
--- a/mozillians/announcements/models.py
+++ b/mozillians/announcements/models.py
@@ -7,12 +7,13 @@ from django.db import models
 from django.core.exceptions import ValidationError
 
 import bleach
+from jinja2 import Markup
 from sorl.thumbnail import ImageField
 
 from mozillians.announcements.managers import AnnouncementManager
 
 
-ALLOWED_TAGS = ['em', 'strong', 'a']
+ALLOWED_TAGS = ['em', 'strong', 'a', 'u']
 
 
 def _calculate_image_filename(instance, filename):
@@ -48,6 +49,10 @@ class Announcement(models.Model):
         now = datetime.now()
         return ((self.publish_from <= now) and
                 (self.publish_until > now if self.publish_until else True))
+
+    def get_template_text(self):
+        """Mark text as template safe so html tags are not escaped."""
+        return Markup(self.text)
 
     def __unicode__(self):
         return self.title

--- a/mozillians/announcements/tests/test_models.py
+++ b/mozillians/announcements/tests/test_models.py
@@ -1,12 +1,13 @@
 from datetime import datetime
 
+from jinja2 import Markup
 from mock import patch
 from nose.tools import ok_
 
 from mozillians.announcements.tests import AnnouncementFactory, TestCase
 
 
-class AnnouncementManagerTests(TestCase):
+class AnnouncementTests(TestCase):
     @patch('mozillians.announcements.models.datetime')
     def test_published(self, mock_obj):
         """Test published model property."""
@@ -21,3 +22,8 @@ class AnnouncementManagerTests(TestCase):
         ok_(first.published)
         ok_(second.published)
         ok_(not third.published)
+
+    def test_get_template_text(self):
+        announcement = AnnouncementFactory.create(publish_from=datetime(2013, 2, 12))
+        text = announcement.get_template_text()
+        ok_(isinstance(text, Markup))

--- a/mozillians/templates/phonebook/home.html
+++ b/mozillians/templates/phonebook/home.html
@@ -180,7 +180,7 @@
             <img src="{{ thumbnail(announcement.image, '60x60').url }}">
           {% endif %}
           <h2>{{ announcement.title }}</h2>
-          <p> {{ announcement.text }} </p>
+          <p> {{ announcement.get_template_text() }} </p>
         {% else %}
           {% set fact=random_funfact() %}
           {% if fact %}


### PR DESCRIPTION
- Also added 'u' in allowed tags.
