### PR TITLE
[Fix bug 969920] Display users' groups per their privacy policy

### DIFF
--- a/mozillians/groups/models.py
+++ b/mozillians/groups/models.py
@@ -262,15 +262,15 @@ class Group(GroupBase):
         """
         Return True if this user is in this group with status MEMBER.
         """
-        return GroupMembership.objects.filter(group=self, userprofile=userprofile,
-                                              status=GroupMembership.MEMBER).exists()
+        return self.groupmembership_set.filter(userprofile=userprofile,
+                                               status=GroupMembership.MEMBER).exists()
 
     def has_pending_member(self, userprofile):
         """
         Return True if this user is in this group with status PENDING.
         """
-        return GroupMembership.objects.filter(group=self, userprofile=userprofile,
-                                              status=GroupMembership.PENDING).exists()
+        return self.groupmembership_set.filter(userprofile=userprofile,
+                                               status=GroupMembership.PENDING).exists()
 
     def get_vouched_annotated_members(self, statuses=None, always_include=None):
         """
@@ -284,8 +284,7 @@ class Group(GroupBase):
         Attribute ``.pending`` indicates whether membership is only pending.
         Attribute ``.is_curator`` indicates if member is a curator of this group
         """
-        memberships = GroupMembership.objects.filter(group=self,
-                                                     userprofile__is_vouched=True)
+        memberships = self.groupmembership_set.filter(userprofile__is_vouched=True)
         if statuses is not None:
             if always_include is not None:
                 memberships = memberships.filter(Q(status__in=statuses)

--- a/mozillians/groups/tasks.py
+++ b/mozillians/groups/tasks.py
@@ -40,8 +40,7 @@ def send_pending_membership_emails():
 
     for group in groups:
         # what's the max pk of pending memberships?
-        pending_memberships = GroupMembership.objects.filter(group=group,
-                                                             status=GroupMembership.PENDING)
+        pending_memberships = group.groupmembership_set.filter(status=GroupMembership.PENDING)
         max_pk = pending_memberships.aggregate(max_pk=Max('pk'))['max_pk']
         # Only send reminder if there are newer requests than we'd previously reminded about
         if max_pk > group.max_reminder:

--- a/mozillians/users/tests/test_models.py
+++ b/mozillians/users/tests/test_models.py
@@ -18,7 +18,7 @@ from mozillians.groups.models import Group, Language, Skill
 from mozillians.groups.tests import (GroupAliasFactory, GroupFactory,
                                      LanguageAliasFactory, LanguageFactory,
                                      SkillAliasFactory, SkillFactory)
-from mozillians.users.managers import EMPLOYEES, MOZILLIANS, PUBLIC, PUBLIC_INDEXABLE_FIELDS
+from mozillians.users.managers import (EMPLOYEES, MOZILLIANS, PUBLIC, PUBLIC_INDEXABLE_FIELDS)
 from mozillians.users.models import ExternalAccount, UserProfile, _calculate_photo_filename
 from mozillians.users.tests import UserFactory
 
@@ -208,6 +208,18 @@ class UserProfileTests(TestCase):
         eq_(profile.websites.count(), 1)
         profile.set_instance_privacy_level(PUBLIC)
         eq_(profile.websites.count(), 0)
+
+    def test_annotated_groups_not_public(self):
+        # Group member who wants their groups kept semi-private
+        profile = UserFactory.create(userprofile={'privacy_groups': MOZILLIANS}).userprofile
+        group = GroupFactory.create(name='group')
+        group.add_member(profile)
+
+        # Being accessed by a member of the general public
+        profile.set_instance_privacy_level(PUBLIC)
+
+        # no groups seen
+        eq_(len(profile.get_annotated_groups()), 0)
 
     @patch('mozillians.users.models.UserProfile.auto_vouch')
     def test_auto_vouch_on_profile_save(self, auto_vouch_mock):


### PR DESCRIPTION
Don't show users' groups if their groups privacy settings
says not to.

(Also changed a few other references to group membership to be a little more Djangonic.)
