### PR TITLE
[Fix bug 977556] Update version of python-memcached

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,6 +2,6 @@
 
 BeautifulSoup<4.0
 django-selectable==0.7.0
-python-memcached==1.45
+python-memcached==1.53
 unidecode
 urllib3


### PR DESCRIPTION
Mozillians' requirements call for a version of python-memcached that apparently has disappeared from PyPI:

Could not find a version that satisfies the requirement python-memcached==1.45 (from -r requirements/prod.txt (line 5)) (from versions: 1.31, 1.47, 1.48, 1.51, 1.52, 1.53)
