### PR TITLE
Replace PIL with pillow.

### DIFF
--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -1,5 +1,4 @@
 -r ../vendor/src/funfactory/funfactory/requirements/compiled.txt
 
 # Images
-PIL
-
+Pillow==2.3.0


### PR DESCRIPTION
I've been using pillow instead of PIL for same time now in my local mozillians install and seems to work fine. Let's replace PIL so people don't get lost with `pip --allow-*`
