### PR TITLE
[Fix bug 980887] Speed up browsing large groups

### DIFF
--- a/mozillians/groups/models.py
+++ b/mozillians/groups/models.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import Q
 from django.utils.timezone import now
 
 from autoslug.fields import AutoSlugField
@@ -300,33 +299,6 @@ class Group(GroupBase):
         """
         return self.groupmembership_set.filter(userprofile=userprofile,
                                                status=GroupMembership.PENDING).exists()
-
-    def get_vouched_annotated_members(self, statuses=None, always_include=None):
-        """
-        Return list of UserProfiles of vouched users who are members or pending members.
-
-        Pass ``statuses`` a list of desired statuses to filter by status too.
-
-        Pass a userprofile in ``always_include`` to include that userprofile regardless
-        of status (so we show a user that they are in the group in pending state).
-
-        Attribute ``.pending`` indicates whether membership is only pending.
-        Attribute ``.is_curator`` indicates if member is a curator of this group
-        """
-        memberships = self.groupmembership_set.filter(userprofile__is_vouched=True)
-        if statuses is not None:
-            if always_include is not None:
-                memberships = memberships.filter(Q(status__in=statuses)
-                                                 | Q(userprofile=always_include))
-            else:
-                memberships = memberships.filter(status__in=statuses)
-        profiles = []
-        for membership in memberships:
-            profile = membership.userprofile
-            profile.pending = (membership.status == GroupMembership.PENDING)
-            profile.is_curator = (self.curator == profile)
-            profiles.append(profile)
-        return profiles
 
 
 class SkillAlias(GroupAliasBase):

--- a/mozillians/groups/tests/test_views_delete.py
+++ b/mozillians/groups/tests/test_views_delete.py
@@ -2,10 +2,10 @@
 
 from mock import patch, MagicMock
 
-from mozillians.groups.views import show, group_delete
+from mozillians.groups.views import group_delete, show_group
 from nose.tools import ok_
 from mozillians.common.tests import TestCase
-from mozillians.groups.models import Group, GroupAlias, GroupMembership
+from mozillians.groups.models import Group, GroupMembership
 from mozillians.groups.tests import GroupFactory
 from mozillians.users.tests import UserFactory
 
@@ -28,7 +28,7 @@ class ShowGroupDeleteTests(TestCase):
 
         with patch('mozillians.groups.views.render') as mock_render:
             with patch('django.views.decorators.cache.add_never_cache_headers'):
-                show(request, self.group.url, GroupAlias, 'groups/group.html')
+                show_group(request, self.group.url, 'groups/group.html')
 
         ok_(mock_render.called)
         args, kwargs = mock_render.call_args

--- a/mozillians/groups/urls.py
+++ b/mozillians/groups/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import patterns, url
 
-from mozillians.groups.models import Group, GroupAlias, Skill, SkillAlias
+from mozillians.groups.models import Group, Skill
 
 
 urlpatterns = patterns(
@@ -14,12 +14,12 @@ urlpatterns = patterns(
     url('^group_edit/(?P<url>[-\'\w]+)/$', 'views.group_add_edit', name='group_edit'),
     url('^group_delete/(?P<url>[-\'\w]+)/$', 'views.group_delete', name='group_delete'),
 
-    url('^group/(?P<url>[-\w]+)/$', 'views.show',
-        {'alias_model': GroupAlias, 'template': 'groups/group.html'},
+    url('^group/(?P<url>[-\w]+)/$', 'views.show_group',
+        {'template': 'groups/group.html'},
         name='show_group'),
 
-    url('^skill/(?P<url>[-\w]+)/$', 'views.show',
-        {'alias_model': SkillAlias, 'template': 'groups/skill.html'},
+    url('^skill/(?P<url>[-\w]+)/$', 'views.show_skill',
+        {'template': 'groups/skill.html'},
         name='show_skill'),
     url('^skill/(?P<url>[-\w]+)/toggle/$', 'views.toggle_skill_subscription',
         name='toggle_skill_subscription'),

--- a/mozillians/phonebook/tests/test_helpers.py
+++ b/mozillians/phonebook/tests/test_helpers.py
@@ -2,7 +2,10 @@ import tower
 from nose.tools import eq_
 
 from mozillians.common.tests import TestCase
-from mozillians.phonebook.helpers import langcode_to_name
+from mozillians.groups.models import GroupMembership
+from mozillians.groups.tests import GroupFactory
+from mozillians.phonebook.helpers import langcode_to_name, search_result_context
+from mozillians.users.tests import UserFactory
 
 
 class LanguageCodeToNameTests(TestCase):
@@ -18,3 +21,19 @@ class LanguageCodeToNameTests(TestCase):
         tower.activate('fr')
         name = langcode_to_name('foobar')
         eq_(name, 'foobar')
+
+
+class SearchResultContextTests(TestCase):
+    def test_profile(self):
+        # Passing a profile puts a profile in the context
+        profile = UserFactory().userprofile
+        x = search_result_context({}, profile)
+        eq_(x['profile'], profile)
+
+    def test_membership(self):
+        # Passing a membership puts a profile in the context
+        profile = UserFactory().userprofile
+        group = GroupFactory()
+        membership = GroupMembership(userprofile=profile, group=group)
+        x = search_result_context({}, membership)
+        eq_(x['profile'], profile)

--- a/mozillians/templates/groups/group.html
+++ b/mozillians/templates/groups/group.html
@@ -154,7 +154,7 @@
       </div>
     {% endif %}
 
-    {% if not people.paginator.count %}
+    {% if not page.paginator.count %}
       <div class="well">
         <p id="not-found">
           {% if r_selected %}
@@ -169,7 +169,7 @@
         </p>
       </div>
     {% else %}
-      {% with items=people %}
+      {% with items=page %}
         {% include 'includes/pagination.html' %}
       {% endwith %}
 
@@ -187,17 +187,14 @@
         </div>
       {% endif %}
 
-
       <br class="clear">
 
       <div class="row">
-        {% for people_slice in people|slice(3) -%}
-          {% for person in people_slice %}
-            {{ search_result(person) }}
-          {% endfor %}
+        {% for membership in page %}
+          {{ search_result(membership) }}
         {% endfor %}
       </div>
-      {% with items=people %}
+      {% with items=page %}
         {% include 'includes/pagination.html' %}
       {% endwith %}
     {% endif %}

--- a/mozillians/templates/groups/skill.html
+++ b/mozillians/templates/groups/skill.html
@@ -25,7 +25,7 @@
     </button>
   </form>
 
-  {% if not people.paginator.count %}
+  {% if not page.paginator.count %}
     <div class="well">
       <p id="not-found">
         {% trans name=group.name %}
@@ -34,17 +34,15 @@
       </p>
     </div>
   {% else %}
-    {% with items=people %}
+    {% with items=page %}
       {% include 'includes/pagination.html' %}
     {% endwith %}
     <div class="row">
-      {% for people_slice in people|slice(3) -%}
-          {% for person in people_slice %}
-            {{ search_result(person) }}
-          {% endfor %}
+      {% for person in page -%}
+        {{ search_result(person) }}
       {% endfor %}
     </div>
-    {% with items=people %}
+    {% with items=page %}
       {% include 'includes/pagination.html' %}
     {% endwith %}
   {% endif %}


### PR DESCRIPTION
Refactor code so we can always give the paginator a queryset without having to iterate through the whole thing first.
