### PR TITLE
[fix bug 962712] Fix missing invitee name.

### DIFF
--- a/mozillians/phonebook/tests/test_views_register.py
+++ b/mozillians/phonebook/tests/test_views_register.py
@@ -5,7 +5,7 @@ from django.test import Client
 from funfactory.helpers import urlparams
 from mozillians.common.tests import TestCase
 from mozillians.phonebook.tests import InviteFactory
-from mozillians.phonebook.utils import update_invites
+from mozillians.phonebook.utils import redeem_invite
 from mozillians.users.tests import UserFactory
 from nose.tools import eq_, ok_
 
@@ -18,9 +18,9 @@ class RegisterTests(TestCase):
         eq_(client.session['invite-code'], 'foo')
         self.assertTemplateUsed(response, 'phonebook/home.html')
 
-    @patch('mozillians.phonebook.views.update_invites',
-           wraps=update_invites)
-    def test_register_unvouched(self, update_invites_mock):
+    @patch('mozillians.phonebook.views.redeem_invite',
+           wraps=redeem_invite)
+    def test_register_unvouched(self, redeem_invite_mock):
         user = UserFactory.create()
         invite = InviteFactory.create(inviter=user.userprofile)
         url = urlparams(reverse('phonebook:register'), code=invite.code)
@@ -28,12 +28,12 @@ class RegisterTests(TestCase):
             response = client.get(url, follow=True)
         user = User.objects.get(id=user.id)
         ok_(user.userprofile.is_vouched)
-        ok_(update_invites_mock.called)
+        ok_(redeem_invite_mock.called)
         self.assertTemplateUsed(response, 'phonebook/home.html')
 
-    @patch('mozillians.phonebook.views.update_invites',
-           wraps=update_invites)
-    def test_register_vouched(self, update_invites_mock):
+    @patch('mozillians.phonebook.views.redeem_invite',
+           wraps=redeem_invite)
+    def test_register_vouched(self, redeem_invite_mock):
         voucher_1 = UserFactory.create(userprofile={'is_vouched': True})
         voucher_2 = UserFactory.create(userprofile={'is_vouched': True})
         user = UserFactory.create(
@@ -46,7 +46,7 @@ class RegisterTests(TestCase):
         user = User.objects.get(id=user.id)
         ok_(user.userprofile.is_vouched)
         ok_(user.userprofile.vouched_by, voucher_1.userprofile)
-        ok_(not update_invites_mock.called)
+        ok_(not redeem_invite_mock.called)
         self.assertTemplateUsed(response, 'phonebook/home.html')
 
     def test_register_without_code_anonymous(self):

--- a/mozillians/phonebook/utils.py
+++ b/mozillians/phonebook/utils.py
@@ -3,8 +3,7 @@ import datetime
 from mozillians.phonebook.models import Invite
 
 
-def update_invites(request):
-    code = request.session.get('invite-code')
+def redeem_invite(redeemer, code):
     if code:
         try:
             invite = Invite.objects.get(code=code, redeemed=None)
@@ -15,7 +14,6 @@ def update_invites(request):
         # If there is no invite, lets get out of here.
         return
 
-    redeemer = request.user.userprofile
     redeemer.vouch(voucher)
     invite.redeemed = datetime.datetime.now()
     invite.redeemer = redeemer

--- a/mozillians/phonebook/views.py
+++ b/mozillians/phonebook/views.py
@@ -22,7 +22,7 @@ from mozillians.common.middleware import LOGIN_MESSAGE, GET_VOUCHED_MESSAGE
 from mozillians.groups.helpers import stringify_groups
 from mozillians.groups.models import Group
 from mozillians.phonebook.models import Invite
-from mozillians.phonebook.utils import update_invites
+from mozillians.phonebook.utils import redeem_invite
 from mozillians.users.managers import EMPLOYEES, MOZILLIANS, PUBLIC, PRIVILEGED
 from mozillians.users.models import COUNTRIES, UserProfile
 
@@ -176,7 +176,8 @@ def edit_profile(request):
 
         # Notify the user that their old profile URL won't work.
         if new_profile:
-            update_invites(request)
+            if request.session.get('invite-code'):
+                redeem_invite(profile, request.session.get('invite-code'))
             messages.info(request, _(u'Your account has been created.'))
         elif user.username != old_username:
             messages.info(request,
@@ -377,7 +378,7 @@ def register(request):
         request.session['invite-code'] = request.GET['code']
         if request.user.is_authenticated():
             if not request.user.userprofile.is_vouched:
-                update_invites(request)
+                redeem_invite(request.user.userprofile, request.session['invite-code'])
         else:
             messages.info(request, _("You've been invited to join Mozillians.org! "
                                      "Sign in and then you can create a profile."))

--- a/mozillians/templates/phonebook/invite_accepted.txt
+++ b/mozillians/templates/phonebook/invite_accepted.txt
@@ -1,10 +1,14 @@
 {% trans %}
 Hi {{ inviter }},
+{% endtrans %}
 
-Thanks to you, your friend {{ friend }} created a profile on mozillians.org.
+{% trans %}
+You invited {{ friend }} to create a profile on mozillians.org. Take a look
+at their shiny, new profile: {{ profile }}
+{% endtrans %}
 
-Take a look at their profile:
-{{ profile }}
+{% trans %}
+Thanks for inviting a contributor to join our community directory!
 {% endtrans %}
 
 {{ _('The Mozillians.org team') }}


### PR DESCRIPTION
Changed `update_invites` and re-named it to `redeem_invite`. Updated tests accordingly.
