### PR TITLE
[fix bug 997666] Use mozillians_field on profile.skills.

### DIFF
--- a/mozillians/phonebook/forms.py
+++ b/mozillians/phonebook/forms.py
@@ -118,8 +118,9 @@ class ProfileForm(happyforms.ModelForm):
         widget=MonthYearWidget(years=range(1998, datetime.today().year + 1),
                                required=False))
     skills = forms.CharField(
-        label=_lazy(u'Start typing to add a skill (example: Python, '
-                    u'javascript, Graphic Design, User Research)'),
+        label='',
+        help_text=_lazy(u'Start typing to add a skill (example: Python, '
+                        u'javascript, Graphic Design, User Research)'),
         required=False)
 
     class Meta:

--- a/mozillians/templates/phonebook/edit_profile.html
+++ b/mozillians/templates/phonebook/edit_profile.html
@@ -282,10 +282,7 @@
           both.
         {% endtrans %}
       </p>
-      {{ profile_form.skills }}
-      <div class="help_text">
-        {{ profile_form.skills.label_tag() }}
-      </div>
+      {{ mozillians_field(profile_form.skills) }}
       {{ privacy_field(profile_form.privacy_skills) }}
     </fieldset>
 


### PR DESCRIPTION
Switch from custom code to mozillians_field() helper to:
- Make code consistent and avoid custom code.
- Display skill errors
