### PR TITLE
[fix bug 995950] Remove jsi18n references.

### DIFF
--- a/mozillians/phonebook/middleware.py
+++ b/mozillians/phonebook/middleware.py
@@ -20,7 +20,7 @@ class RegisterMiddleware():
                       r'^/[\w-]+{0}'.format(reverse('phonebook:profile_edit')),
                       r'^/browserid/',
                       r'^/[\w-]+{0}'.format(reverse('phonebook:login')),
-                      r'^/[\w-]+/jsi18n/']
+                      ]
 
         if settings.DEBUG:
             allow_urls.append(settings.MEDIA_URL)

--- a/mozillians/settings/base.py
+++ b/mozillians/settings/base.py
@@ -262,7 +262,6 @@ STRONGHOLD_EXCEPTIONS = ['^%s' % MEDIA_URL,
                          '^/csp/',
                          '^/admin/',
                          '^/browserid/',
-                         '^/jsi18n',
                          '^/api/']
 
 # Set default avatar for user profiles

--- a/mozillians/templates/base.html
+++ b/mozillians/templates/base.html
@@ -212,8 +212,6 @@
     {% endblock %}
   </div><!-- close #outer-wrapper -->
 
-  <script src="{{ url('jsi18n') }}"></script>
-
   {% block site_js %}
     {% compress js %}
       <script src="{{ static('mozillians/js/libs/jquery-1.7.2.js') }}"></script>

--- a/mozillians/urls.py
+++ b/mozillians/urls.py
@@ -2,14 +2,10 @@ from django.conf import settings
 from django.conf.urls.defaults import include, patterns, url
 from django.contrib import admin
 from django.shortcuts import render
-from django.views.decorators.cache import cache_page
-from django.views.i18n import javascript_catalog
 
 import autocomplete_light
 
 from funfactory.monkeypatches import patch
-
-from mozillians.common.decorators import allow_public
 
 
 # Funfactory monkeypatches
@@ -62,10 +58,6 @@ urlpatterns = patterns(
     # Admin URLs.
     url(r'^admin/', include(admin.site.urls)),
     url(r'^_autocomplete/', include('autocomplete_light.urls')),
-
-    url(r'^jsi18n/$',
-        allow_public(cache_page(60 * 60 * 24 * 365)(javascript_catalog)),
-        {'domain': 'javascript', 'packages': ['mozillians']}, name='jsi18n'),
 
     url(r'', include('mozillians.humans.urls', 'humans')),
 )


### PR DESCRIPTION
We don't use django's built in javascript translation tools. This commit
removes related code.
