### PR TITLE
Privacy policy url fixed

### DIFF
--- a/mozillians/templates/phonebook/about.html
+++ b/mozillians/templates/phonebook/about.html
@@ -35,7 +35,7 @@
       <h2>{{ _('Privacy First') }}</h2>
       <p>
         {% trans privacy_policy_url=('http://www.mozilla.org/'
-                                     + LANG +'/privacy-policy.html') %}
+                                     + LANG +'/privacy/websites/') %}
           Privacy has been an important part of this directory from the very
           beginning. We want to make sure we provide Mozillians with the best
           experience possible, from the way the site is built to the way we


### PR DESCRIPTION
The url for the privacy policy has changed from http://www.mozilla.org/privacy-policy.html to http://www.mozilla.org/privacy/websites/

The privacy policy url under https://mozillians.org/about/#privacy has been be updated 
