### PR TITLE
[Fix Bug #962172] Add 'LinkedIn' to Account Types.

### DIFF
--- a/mozillians/users/models.py
+++ b/mozillians/users/models.py
@@ -697,6 +697,7 @@ class ExternalAccount(models.Model):
     TYPE_WEBMAKER = 'WEBMAKER'
     TYPE_MOWIKI = 'MOZILLAWIKI'
     TYPE_REMO = 'REMO'
+    TYPE_LINKEDIN = 'LINKEDIN'
 
     # Account type field documentation:
     # name: The name of the service that this account belongs to. What
@@ -747,7 +748,10 @@ class ExternalAccount(models.Model):
         TYPE_MOWIKI: {'name': 'Mozilla Wiki', 'url': 'https://wiki.mozilla.org/User:{identifier}',
                       'validator': validate_username_not_url},
         TYPE_REMO: {'name': 'Mozilla Reps', 'url': 'https://reps.mozilla.org/u/{identifier}/',
-                    'validator': validate_username_not_url}
+                    'validator': validate_username_not_url},
+        TYPE_LINKEDIN: {'name': 'LinkedIn',
+                        'url': '',
+                        'validator': validate_website}
     }
 
     user = models.ForeignKey(UserProfile)


### PR DESCRIPTION
This is the new patch. Have left the url empty and used validate_website to validate the link to user profile.
