### PR TITLE
Fix deprecation warnings.

### DIFF
--- a/mozillians/api/urls.py
+++ b/mozillians/api/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import include, patterns, url
+from django.conf.urls import include, patterns, url
 
 from tastypie.api import Api
 

--- a/mozillians/common/tests/stronghold_urls.py
+++ b/mozillians/common/tests/stronghold_urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.http import HttpResponse
 from mozillians.common.decorators import allow_public, allow_unvouched
 

--- a/mozillians/humans/urls.py
+++ b/mozillians/humans/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     'mozillians.humans',

--- a/mozillians/phonebook/urls.py
+++ b/mozillians/phonebook/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.views.generic import TemplateView
 
 from mozillians.common.decorators import allow_public

--- a/mozillians/urls.py
+++ b/mozillians/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls.defaults import include, patterns, url
+from django.conf.urls import include, patterns, url
 from django.contrib import admin
 from django.shortcuts import render
 

--- a/mozillians/users/admin.py
+++ b/mozillians/users/admin.py
@@ -2,7 +2,7 @@ import csv
 from datetime import datetime, timedelta
 
 from django import forms
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.contrib import admin
 from django.contrib import messages
 from django.contrib.admin import SimpleListFilter


### PR DESCRIPTION
- DeprecationWarning: django.conf.urls.defaults is deprecated; use django.conf.urls instead
