### PR TITLE
[bug 991553] Invisible groups are visible

### DIFF
--- a/mozillians/templates/phonebook/home.html
+++ b/mozillians/templates/phonebook/home.html
@@ -116,16 +116,18 @@
           <section class="groups">
             <h4>{{ _('Groups') }}</h4>
             {% for membership in user.userprofile.groupmembership_set.all() -%}
-              {%- with group=membership.group -%}
-              <a href="{{ url('groups:show_group', group.url) }}">
-                {%- if group.curator == user.userprofile -%}
-                  <i class="icon-crown"></i>
-                {% endif %}
-                {{ group.name }}
-                {%- if membership.status == 'pending' %} {{ _('(membership requested)') }}{% endif -%}
-              </a>
-              {%- endwith -%}
+              {% if membership.group.visible == True %}
+                {%- with group=membership.group -%}
+                <a href="{{ url('groups:show_group', group.url) }}">
+                  {%- if group.curator == user.userprofile -%}
+                    <i class="icon-crown"></i>
+                  {% endif %}
+                  {{ group.name }}
+                  {%- if membership.status == 'pending' %} {{ _('(membership requested)') }}{% endif -%}
+                </a>
+                {%- endwith -%}
               {%- if not loop.last -%},{% endif %}
+              {% endif %}
             {% endfor %}
           </section>
         {% endif %}

--- a/mozillians/users/models.py
+++ b/mozillians/users/models.py
@@ -582,7 +582,7 @@ class UserProfile(UserProfilePrivacyModel, SearchMixin):
 
     def get_annotated_groups(self):
         """
-        Return a list of all the groups the user is a member of or pending
+        Return a list of all visible groups the user is a member of or pending
         membership. The groups pending membership will have a .pending attribute
         set to True, others will have it set False.
         """
@@ -594,7 +594,8 @@ class UserProfile(UserProfilePrivacyModel, SearchMixin):
         for membership in self.groupmembership_set.filter(group_id__in=user_group_ids):
             group = membership.group
             group.pending = (membership.status == GroupMembership.PENDING)
-            groups.append(group)
+            if group.visible is True:
+                groups.append(group)
         return groups
 
     def timezone_offset(self):

--- a/mozillians/users/tests/test_models.py
+++ b/mozillians/users/tests/test_models.py
@@ -248,6 +248,16 @@ class UserProfileTests(TestCase):
         user_groups = user_1.userprofile.get_annotated_groups()
         eq_([group_1], user_groups)
 
+    def test_get_annotated_groups_return_visible_groups_only(self):
+        user_1 = UserFactory.create()
+        group_1 = GroupFactory.create()
+        group_1.add_member(user_1.userprofile)
+        group_2 = GroupFactory.create(visible=False)
+        group_2.add_member(user_1.userprofile)
+
+        # only one group seen
+        eq_(len(user_1.userprofile.get_annotated_groups()), 1)
+
     @patch('mozillians.users.models.UserProfile.auto_vouch')
     def test_auto_vouch_on_profile_save(self, auto_vouch_mock):
         UserFactory.create()


### PR DESCRIPTION
Function get_annotated_groups is only called from view_profile so I changed its behavior and not created another function for returning visible groups only.
If this is not appropriate i'll change the code.
