### PR TITLE
[fix bug 1015759] Curated groups - keep active filtering after confirmation of membership request

### DIFF
--- a/mozillians/templates/groups/confirm_remove_member.html
+++ b/mozillians/templates/groups/confirm_remove_member.html
@@ -23,9 +23,10 @@
 
    <form action="{{ url('groups:remove_member', url=group.url, user_pk=profile.pk) }}" method="POST">
      {{ csrf() }}
+     <input type="hidden" name="next_url" value="{{ next_url }}" />
      <button class="button remove" type="submit">{{ _('Remove') }}</button>
   </form>
 
-  <a href="{{ url('groups:show_group', group.url) }}">{{ _('Return to group') }}</a>
+  <a href="{{ next_url }}">{{ _('Return to group') }}</a>
 
 {% endblock content %}

--- a/mozillians/templates/includes/search_result.html
+++ b/mozillians/templates/includes/search_result.html
@@ -5,6 +5,7 @@
         <form action="{{ url('groups:remove_member', url=group.url, user_pk=profile.pk) }}"
               method="GET">
           {{ csrf() }}
+          <input type="hidden" name="next_url" value="{{ request.get_full_path() }}" />
           <button type="submit" class="button remove">{{ _('Remove') }} <i class="icon-close"></i></button>
         </form>
       {% endif %}
@@ -12,6 +13,7 @@
         <form action="{{ url('groups:confirm_member', url=group.url, user_pk=profile.pk) }}"
               method="POST">
           {{ csrf() }}
+          <input type="hidden" name="next_url" value="{{ request.get_full_path() }}" />
           <button type="submit" class="status-pending">{{ _('Confirm Request') }}</span></button>
         </form>
       {% endif %}


### PR DESCRIPTION
this time using next_url param as @glogiotatidis suggested on my first attempt
https://github.com/mozilla/mozillians/pull/963
