### PR TITLE
[Fix Bug 1056838] Changing Google Talk string to hangouts

### DIFF
--- a/mozillians/users/models.py
+++ b/mozillians/users/models.py
@@ -909,7 +909,7 @@ class ExternalAccount(models.Model):
                        'url': 'https://twitter.com/{identifier}',
                        'validator': validate_twitter},
         TYPE_AIM: {'name': 'AIM', 'url': ''},
-        TYPE_GTALK: {'name': 'Google Talk',
+        TYPE_GTALK: {'name': 'Google+ Hangouts',
                      'url': '',
                      'validator': validate_email},
         TYPE_SKYPE: {'name': 'Skype', 'url': ''},


### PR DESCRIPTION
Google talk is now Google hangout, we should update it!

if you got to this page: http://www.google.com/talk/index.html 

it will redirect to New Hangout website!
