### PR TITLE
Clarify the email validator error message

### DIFF
--- a/mozillians/phonebook/validators.py
+++ b/mozillians/phonebook/validators.py
@@ -72,7 +72,7 @@ def validate_username_not_url(username):
 def validate_email(value):
     """Validate that a username is email like."""
     if not email_re.match(value):
-        raise ValidationError(_('Enter a valid address.'))
+        raise ValidationError(_('Enter a valid email address.'))
     return value
 
 


### PR DESCRIPTION
The existing error message is ambiguous as to what type of "address" should be typed in (e.g. web, email, mailing). This updates the error message to specify that the input failed validation because it wasn't an "email" address.
More info on the spelling of email : http://en.wikipedia.org/wiki/Email#Spelling
