### PR TITLE
Added an id to the group name element

### DIFF
--- a/mozillians/templates/groups/group.html
+++ b/mozillians/templates/groups/group.html
@@ -11,7 +11,7 @@
 
 {% block content %}
 
-    <h1>
+    <h1 id="group_name">
     {% if group.functional_area %}
         {{ _('Functional Area') }}:
     {% else %}


### PR DESCRIPTION
Fix for bug 1111856 -  Add ID to group name on specific group pages
