### PR TITLE
correct contribute.json URL

### DIFF
--- a/mozillians/humans/urls.py
+++ b/mozillians/humans/urls.py
@@ -3,5 +3,5 @@ from django.conf.urls import patterns, url
 urlpatterns = patterns(
     'mozillians.humans',
     url(r'^humans.txt$', 'views.humans', name='humans'),
-    url(r'^contribute.json/$', 'views.contribute_view', name='contribute-view')
+    url(r'^contribute.json$', 'views.contribute_view', name='contribute-view')
 )


### PR DESCRIPTION
The "correct" URL should not have a trailing `/`. 

I say correct in quotation marks because it's actually not uber important but more the fact that all other projects don't use a trailing slash. See http://contribute.paas.allizom.org/examples

Also, if we add a button to the FirefoxDeveloperEdition that checks for a `/contribute.json` presence then we might cause an unnecessary redirect. 

PS. I did not run the tests for this patch. I don't have the project set up other than a git fork. 