### PR TITLE
Use consistent border-color for both inputs and textareas

### DIFF
--- a/mozillians/static/mozillians/css/main.less
+++ b/mozillians/static/mozillians/css/main.less
@@ -1365,9 +1365,6 @@ form {
         padding-bottom: 20px;
         border-bottom: 1px solid lighten(@black,90%);
         position: relative;
-        input, textarea {
-            border: 1px solid lighten(@black,90%);
-        }
 
         label {
             margin-right: 8px;


### PR DESCRIPTION
Currenly textareas have a lighten border color. (See Bio at [edit profile](https://mozillians.org/en-US/user/edit/) for example). This is caused because we overwrite sandstone's default.