### PR TITLE
[fix bug 1134866] Update Bugzilla links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Contribute
 
 File a bug
 ------
-[Create a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Community%20Tools&component=Phonebook) on bugzilla.mozilla.org in the `Community Tools > Phonebook` component. If you then want to give a Pull Request, mention the bug number in the pull request to help with tracking. Here's an example commit message for a bug fix:
+[Create a bug](https://bugzilla.mozilla.org/enter_bug.cgi?product=Participation%20Infrastructure&component=Phonebook) on bugzilla.mozilla.org in the `Participation Infrastructure > Phonebook` component. If you then want to give a Pull Request, mention the bug number in the pull request to help with tracking. Here's an example commit message for a bug fix:
 ```
 [fix bug 937104] Update to latest playdoh.
 ```

--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -23,12 +23,12 @@ The Mozillians.org API exposes personal data about people who have created profi
 #. **Do not expose Mozillians.org data to an audience it was not intended for.** Mozillians.org data is visible, by default, to vouched members of Mozillians.org. Your application must not expose it to a wider audience unless specifically allowed by per-field privacy level or following a data safety review.
 #. **Respect per-field privacy levels.** Certain fields retrieved from the Mozillians.org API may be subject to user-configured privacy levels. These privacy levels may be less restrictive than the default ("public") or more restrictive ("privileged"). *In future releases of the API*, a particular field's privacy level may accompany the field in the API response. Your application must respect and enforce any privacy level present in an API response.
 
-If you believe an application is misusing Mozillians.org API data, please `file a bug <https://bugzilla.mozilla.org/enter_bug.cgi?product=Community%20Tools&component=Phonebook>`_.
+If you believe an application is misusing Mozillians.org API data, please `file a bug <https://bugzilla.mozilla.org/enter_bug.cgi?product=Participation%20Infrastructure&component=Phonebook>`_.
 
 Getting an API Key
 ------------------
 
-Community sites and Mozilla Corporation sites can request an API key by `submitting a bug <https://bugzilla.mozilla.org/enter_bug.cgi?product=Community%20Tools&component=API%20Requests>`_. The bug should include the **URL and description of the application** and **details about the expected use of API data**.
+Community sites and Mozilla Corporation sites can request an API key by `submitting a bug <https://bugzilla.mozilla.org/enter_bug.cgi?product=Participation%20Infrastructure&component=API%20Requests>`_. The bug should include the **URL and description of the application** and **details about the expected use of API data**.
 
 All requests are reviewed by product owners and data safety experts; not all requests are approved. 
 

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -172,7 +172,7 @@ Mozillians development follows a `schedule`_ and a `roadmap`_ managed by the `Mo
 .. _Mozillians product and development team: https://wiki.mozilla.org/Mozillians#Team
 .. _schedule: https://wiki.mozilla.org/Mozillians#Schedule
 .. _roadmap: https://wiki.mozilla.org/Mozillians/RoadMap
-.. _All outstanding bugs: https://bugzilla.mozilla.org/buglist.cgi?product=Community%20Tools;component=Phonebook;resolution=---;list_id=5645789
-.. _Good first bugs: https://bugzilla.mozilla.org/buglist.cgi?list_id=5667806;classification=Other;status_whiteboard_type=allwordssubstr;query_format=advanced;status_whiteboard=mentor;bug_status=NEW;component=Phonebook;product=Community%20Tools
+.. _All outstanding bugs: https://bugzilla.mozilla.org/buglist.cgi?product=Participation%20Infrastructure;component=Phonebook;resolution=---;list_id=5645789
+.. _Good first bugs: https://bugzilla.mozilla.org/buglist.cgi?list_id=5667806;classification=Other;status_whiteboard_type=allwordssubstr;query_format=advanced;status_whiteboard=mentor;bug_status=NEW;component=Phonebook;product=Participation%20Infrastructure
 .. _pull request: https://github.com/YOUR_USERNAME/mozillians/pull/new/master
-.. _submit a bug: https://bugzilla.mozilla.org/enter_bug.cgi?product=Community%20Tools&component=Phonebook&status_whiteboard=&target_milestone=---&version=other
+.. _submit a bug: https://bugzilla.mozilla.org/enter_bug.cgi?product=Participation%20Infrastructure&component=Phonebook&status_whiteboard=&target_milestone=---&version=other

--- a/mozillians/humans/templates/humans/contribute.json
+++ b/mozillians/humans/templates/humans/contribute.json
@@ -18,8 +18,8 @@
         ]
     },
     "bugs": {
-        "list": "https://bugzilla.mozilla.org/buglist.cgi?quicksearch=OPEN%20product%3A%22Community%20Tools%22%20component%3APhonebook",
-        "report": "https://bugzilla.mozilla.org/enter_bug.cgi?product=Community%20Tools&component=Phonebook"
+        "list": "https://bugzilla.mozilla.org/buglist.cgi?quicksearch=OPEN%20product%3A%22Participation%20Infrastructure%22%20component%3APhonebook",
+        "report": "https://bugzilla.mozilla.org/enter_bug.cgi?product=Participation%20Infrastructure&component=Phonebook"
     },
     "urls": {
         "prod": "https://mozillians.org",

--- a/mozillians/templates/500.html
+++ b/mozillians/templates/500.html
@@ -14,7 +14,7 @@
 
   {% trans home_url=url('phonebook:home'),
            bugzilla_url=('https://bugzilla.mozilla.org/enter_bug.cgi?'
-                         'product=Community%20Tools&component=Phonebook') %}
+                         'product=Participation%20Infrastructure&component=Phonebook') %}
     <p>
       Sorry, but we encountered an unexpected error and can't process your
       request. You can try again by refreshing your browser or you can

--- a/mozillians/templates/base.html
+++ b/mozillians/templates/base.html
@@ -181,7 +181,7 @@
           <div class="row">
 
             <h5>
-              {% trans bug_url='https://bugzilla.mozilla.org/enter_bug.cgi?product=Community%20Tools&component=Phonebook',
+              {% trans bug_url='https://bugzilla.mozilla.org/enter_bug.cgi?product=Participation%20Infrastructure&component=Phonebook',
                    git_url='https://github.com/mozilla/mozillians' %}
                 Help make Mozillians better.
                 <a href="{{ bug_url }}">File a bug</a> or


### PR DESCRIPTION
The component name changed from Community Tools to Participation Infrastructure.

Bugzilla bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1134866