### PR TITLE
[Bug 1196244] Remove duplicate legacy code.

### DIFF
--- a/mozillians/groups/forms.py
+++ b/mozillians/groups/forms.py
@@ -37,23 +37,6 @@ class GroupForm(happyforms.ModelForm):
                 del cleaned_data['new_member_criteria']
         return cleaned_data
 
-    def clean_name(self):
-        """Verify that name is unique in ALIAS_MODEL.
-
-        We have to duplicate code here and in
-        models.GroupBase.clean due to bug
-        https://code.djangoproject.com/ticket/16986. To update when we
-        upgrade to Django 1.7.
-
-        """
-        name = self.cleaned_data['name']
-        query = GroupAlias.objects.filter(name=name)
-        if self.instance.pk:
-            query = query.exclude(alias=self.instance)
-        if query.exists():
-            raise ValidationError(_('Group with this Name already exists.'))
-        return name
-
     class Meta:
         model = Group
         fields = ['name', 'description', 'irc_channel',

--- a/mozillians/groups/models.py
+++ b/mozillians/groups/models.py
@@ -26,14 +26,8 @@ class GroupBase(models.Model):
         ordering = ['name']
 
     def clean(self):
-        """Verify that name is unique in ALIAS_MODEL.
+        """Verify that name is unique in ALIAS_MODEL."""
 
-        We have to duplicate code here and in
-        forms.GroupForm.clean_name due to bug
-        https://code.djangoproject.com/ticket/16986. To update when we
-        upgrade to Django 1.7.
-
-        """
         super(GroupBase, self).clean()
         query = self.ALIAS_MODEL.objects.filter(name=self.name)
         if self.pk:

--- a/mozillians/groups/tests/test_forms.py
+++ b/mozillians/groups/tests/test_forms.py
@@ -12,6 +12,8 @@ class GroupFormTests(TestCase):
         form = GroupForm({'name': 'bar'})
         ok_(not form.is_valid())
         ok_('name' in form.errors)
+        msg = u'This name already exists.'
+        ok_(msg in form.errors['name'])
 
     def test_by_request_group_without_new_member_criteria(self):
         form_data = {'name': 'test group', 'accepting_new_members': 'by_request'}


### PR DESCRIPTION
We used duplicate code in groups/{forms,models}.py because of this:
https://code.djangoproject.com/ticket/16986

Now with Django 1.7 model can clean individual fields and there is
no need to clean both `ModelForm` and `Model`.