### PR TITLE
[bug 1196244] Remove admin.autodiscover from url conf.

### DIFF
--- a/mozillians/urls.py
+++ b/mozillians/urls.py
@@ -12,7 +12,6 @@ from mozillians.common.monkeypatches import patch
 patch()
 
 autocomplete_light.autodiscover()
-admin.autodiscover()
 
 # Activate a locale so that jinja2 doesn't choke when running a shell
 # or individual tests that need translation and don't involve a web


### PR DESCRIPTION
* https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#discovery-of-admin-files