### PR TITLE
Fix API v2 boolean parameter value documentation.

### DIFF
--- a/docs/api/apiv2/api-groups.rst
+++ b/docs/api/apiv2/api-groups.rst
@@ -28,13 +28,13 @@ Parameters
         *Optional* **integer** - Return results matching given mozillians id
 
     ``functional_area``
-        *Optional* **true/false** - Return results containing only groups that are functional areas
+        *Optional* **True/False** - Return results containing only groups that are functional areas
 
     ``members_can_leave``
-        *Optional* **true/false** - Return results containing groups with ``members_can_leave`` policy
+        *Optional* **True/False** - Return results containing groups with ``members_can_leave`` policy
 
     ``accepting_new_members``
-        *Optional* **true/false** - Return results containing only groups with ``accepting_new_members`` policy
+        *Optional* **True/False** - Return results containing only groups with ``accepting_new_members`` policy
 
     ``page``
         *Optional* **integer** - Return results contained in specific page

--- a/docs/api/apiv2/api-users.rst
+++ b/docs/api/apiv2/api-users.rst
@@ -22,7 +22,7 @@ Parameters
         *Required* **string** - The application's API key
 
     ``is_vouched``
-        *Optional* **string (true/false)** - Return only vouched/unvouched users
+        *Optional* **string (True/False)** - Return only vouched/unvouched users
 
     ``username``
         *Optional* **string** - Return user with matching username


### PR DESCRIPTION
The paramter values `true` and `false` don't work, however `True` and `False` work.