### PR TITLE
Use migrate instead of syncdb

### DIFF
--- a/docs/installation/installation-docker.rst
+++ b/docs/installation/installation-docker.rst
@@ -66,7 +66,7 @@ Building mozillians
 
 #. Create the database tables and run the migrations::
 
-     $ docker-compose run web python manage.py syncdb --noinput --migrate
+     $ docker-compose run web python manage.py migrate --noinput
 
 #. Load the timezone tables to MySQL::
 


### PR DESCRIPTION
A tiny fix on documentation. syncdb is deprecated on latest versions of Django.