### PR TITLE
Render `create group` errors on form submission.

### DIFF
--- a/mozillians/groups/forms.py
+++ b/mozillians/groups/forms.py
@@ -164,7 +164,6 @@ class GroupCriteriaForm(happyforms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop('request', None)
         super(GroupCriteriaForm, self).__init__(*args, **kwargs)
-        self.fields['accepting_new_members'].label = 'Select Group Type'
 
     def clean(self):
         cleaned_data = super(GroupCriteriaForm, self).clean()
@@ -187,6 +186,9 @@ class GroupCriteriaForm(happyforms.ModelForm):
         fields = ('accepting_new_members', 'new_member_criteria',)
         widgets = {
             'accepting_new_members': forms.RadioSelect(renderer=HorizontalRadioRenderer)
+        }
+        labels = {
+            'accepting_new_members': _('Select Group Type')
         }
 
 
@@ -251,4 +253,7 @@ class CreateGroupForm(forms.ModelForm):
         fields = ('name', 'accepting_new_members')
         widgets = {
             'accepting_new_members': forms.RadioSelect(renderer=HorizontalRadioRenderer)
+        }
+        labels = {
+            'accepting_new_members': _('Group type')
         }

--- a/mozillians/jinja2/groups/index_groups.html
+++ b/mozillians/jinja2/groups/index_groups.html
@@ -21,9 +21,9 @@
   {{ super() }}
 
   <!-- Modal -->
-  <form class="add-group" method="POST" action="{{ url('groups:index_groups') }}">
-    {% csrf_token %}
-    <div class="modal fade" id="GroupModal" tabindex="-1" role="dialog" aria-labelledby="GroupModalLabel">
+  <div class="modal fade" id="GroupModal" tabindex="-1" role="dialog" aria-labelledby="GroupModalLabel">
+    <form class="add-group" method="POST" action="{{ url('groups:index_groups') }}">
+      {% csrf_token %}
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
@@ -33,17 +33,13 @@
           <div class="modal-body">
             <fieldset id="access">
               <div class="form-group">
-                <label class="required" for="id_name">{{ _('Name') }}</label>
-                {{ group_form.name }}
+                {{ mozillians_field(group_form.name) }}
               </div>
             </fieldset>
             <fieldset id="access">
               <div class="form-group">
                 <div class="sizing">
-                  <div>
-                    <label class="required">{{ _('Group type') }}</label>
-                  </div>
-                  {{ group_form.accepting_new_members }}
+                  {{ mozillians_field(group_form.accepting_new_members) }}
                 </div>
               </div>
             </fieldset>
@@ -54,6 +50,12 @@
           </div>
         </div>
       </div>
-    </div>
-  </form>
+    </form>
+  </div>
 {% endblock content %}
+
+{% block page_js %}
+  {% compress js %}
+    <script src="{{ static('mozillians/js/group_index.js') }}"></script>
+  {% endcompress %}
+{% endblock %}

--- a/mozillians/static/mozillians/js/group_index.js
+++ b/mozillians/static/mozillians/js/group_index.js
@@ -1,0 +1,10 @@
+$(function() {
+    'use strict';
+
+    var $create_group_modal = $('#GroupModal');
+    var $create_group_form_errors = $('#GroupModal .add-group .error-message');
+
+    if ($create_group_form_errors.length){
+        $create_group_modal.modal('show');
+    }
+});


### PR DESCRIPTION
* Use Meta.labels instead of manually patching __init__
* Fix l10n issue