### PR TITLE
Remove the readonly field in Invites admin.

### DIFF
--- a/mozillians/groups/admin.py
+++ b/mozillians/groups/admin.py
@@ -332,7 +332,7 @@ class InviteAutocompleteForm(forms.ModelForm):
 class InviteAdmin(ExportMixin, admin.ModelAdmin):
     search_fields = ['inviter', 'redeemer', 'group']
     list_display = ['inviter', 'redeemer', 'group']
-    readonly_fields = ['accepted', 'created', 'updated']
+    readonly_fields = ['created', 'updated']
     list_filter = [RedeemedInviteFilter]
     form = InviteAutocompleteForm
 


### PR DESCRIPTION
@comzeradd quick r?

I removed this for two reasons.

1) All the superusers are able to edit this through mozillians.org so it doesn't  really make sense to have this as readonly in admin.

2) It's easier to edit this through admin, especially during dev.