### PR TITLE
Fix docker build issues.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:2.7.10
 ADD . /code
 WORKDIR /code
-RUN apt-get update
-RUN apt-get install -y mysql-client node-less
+RUN apt-get update && apt-get install -y mysql-client node-less
 RUN ./peep.sh install -r requirements/dev.txt


### PR DESCRIPTION
* `apt-get update` gets cached and in case it fails the whole build
  fails
* It's best practice to run all `apt` related commands to a single RUN