### PR TITLE
Use HTTPS scheme for contribute URL

### DIFF
--- a/mozillians/jinja2/phonebook/profile.html
+++ b/mozillians/jinja2/phonebook/profile.html
@@ -23,7 +23,7 @@
       <div id="pending-approval">
         {% trans vouching_url='https://wiki.mozilla.org/Mozillians/Vouching',
                  profile_url=absolutify(url('phonebook:profile_view', user.username)),
-                 contribute_url='http://www.mozilla.org/contribute' %}
+                 contribute_url='https://www.mozilla.org/contribute' %}
           <p>
             Your profile is waiting to be vouched. Once you are vouched,
             you will be able to view the profiles of all Mozillians,


### PR DESCRIPTION
This hardcoded HTTP URL and another (the privacy_policy_url in https://github.com/mozilla/mozillians/blob/1ebc088c297a245bd8b156b0e4a3617f38c99c8b/mozillians/jinja2/phonebook/about.html#L37-L38) are coming up in another bug as a small issue (can catch you up, offline).  Should be a safe change.

r? @akatsoulas @johngian 