### PR TITLE
Use HTTPS scheme for privacy URL

### DIFF
--- a/mozillians/jinja2/phonebook/about.html
+++ b/mozillians/jinja2/phonebook/about.html
@@ -34,7 +34,7 @@
     <section id="privacy" class="key-info">
       <h2>{{ _('Privacy First') }}</h2>
       <p>
-        {% trans privacy_policy_url=('http://www.mozilla.org/'
+        {% trans privacy_policy_url=('https://www.mozilla.org/'
                                      + LANG +'/privacy/websites/') %}
           Privacy has been an important part of this directory from the very
           beginning. We want to make sure we provide Mozillians with the best


### PR DESCRIPTION
Should be safe to default to HTTPS (and avoids an extra HTTP redirect).