### PR TITLE
Fix http:// -> https:// for "mozilla" workdmark

### DIFF
--- a/mozillians/jinja2/base.html
+++ b/mozillians/jinja2/base.html
@@ -199,7 +199,7 @@
             <hr>
 
             <div class="footer-logo">
-              <a href="http://mozilla.org"><img src="{{ static('mozillians/img/footer-mozilla.png') }}" alt="mozilla"></a>
+              <a href="https://mozilla.org"><img src="{{ static('mozillians/img/footer-mozilla.png') }}" alt="mozilla"></a>
             </div>
 
             <div class="footer-license">


### PR DESCRIPTION
Context for this is: I'm still trying to fix HTTP links, due to https://bugzilla.mozilla.org/show_bug.cgi?id=1267407#c9