### PR TITLE
Refactor basket tasks to take `newsletters` as input

### DIFF
--- a/mozillians/phonebook/management/commands/check_basket.py
+++ b/mozillians/phonebook/management/commands/check_basket.py
@@ -21,7 +21,8 @@ class Command(BaseCommand):
         # The tasks module looks these up at import time, and might get BASKET_API_KEY
         # from the environment rather than settings if it's there, so look directly at
         # what values the tasks module ended up with.
-        required_settings = ['BASKET_API_KEY', 'BASKET_NEWSLETTER', 'BASKET_URL']
+        required_settings = ['BASKET_API_KEY', 'BASKET_NDA_NEWSLETTER',
+                             'BASKET_URL', 'BASKET_VOUCHED_NEWSLETTER']
         if not all([getattr(tasks, setting, False) for setting in required_settings]):
             # At least one is missing. Show what's set and what's missing:
             for setting in required_settings:

--- a/mozillians/phonebook/tests/test_check_basket.py
+++ b/mozillians/phonebook/tests/test_check_basket.py
@@ -13,7 +13,6 @@ from mozillians.phonebook.management.commands.check_basket import Command
 
 # valid-looking settings to use
 @patch('mozillians.users.tasks.BASKET_API_KEY', new='foo')
-@patch('mozillians.users.tasks.BASKET_NEWSLETTER', new='mozillians')
 @patch('mozillians.users.tasks.BASKET_URL', new='https://basket.example.com')
 class CheckBasketTests(TestCase):
     def run_check(self, user_exists=True, http_error=False):
@@ -65,9 +64,14 @@ class CheckBasketTests(TestCase):
         with patch('mozillians.users.tasks.BASKET_URL', new=None):
             ok_(not self.run_check())
 
-    def test_no_newsletter(self):
-        # If BASKET_NEWSLETTER is not set, the check fails
-        with patch('mozillians.users.tasks.BASKET_NEWSLETTER', new=None):
+    def test_no_vouched_newsletter(self):
+        # If BASKET_VOUCHED_NEWSLETTER is not set, the check fails
+        with patch('mozillians.users.tasks.BASKET_VOUCHED_NEWSLETTER', new=None):
+            ok_(not self.run_check())
+
+    def test_no_nda_newsletter(self):
+        # If BASKET_NDA_NEWSLETTER is not set, the check fails
+        with patch('mozillians.users.tasks.BASKET_NDA_NEWSLETTER', new=None):
             ok_(not self.run_check())
 
     def test_no_api_key(self):
@@ -78,6 +82,5 @@ class CheckBasketTests(TestCase):
     def test_multiple_missing_settings(self):
         # If multiple things are missing, check still fails
         with patch('mozillians.users.tasks.BASKET_API_KEY', new=None):
-            with patch('mozillians.users.tasks.BASKET_NEWSLETTER', new=None):
-                with patch('mozillians.users.tasks.BASKET_URL', new=None):
-                    ok_(not self.run_check())
+            with patch('mozillians.users.tasks.BASKET_URL', new=None):
+                ok_(not self.run_check())

--- a/mozillians/phonebook/tests/test_views/test_views_delete.py
+++ b/mozillians/phonebook/tests/test_views/test_views_delete.py
@@ -49,6 +49,7 @@ class DeleteTests(TestCase):
 
     @patch('mozillians.users.models.unsubscribe_from_basket_task.delay')
     @patch('mozillians.users.models.unindex_objects.delay')
+    @override_settings(BASKET_VOUCHED_NEWSLETTER='newsletter')
     def test_delete_unvouched(self, unindex_objects_mock,
                               unsubscribe_from_basket_task_mock):
         user = UserFactory.create(vouched=False, userprofile={'basket_token': 'token'})
@@ -60,7 +61,7 @@ class DeleteTests(TestCase):
         self.assertJinja2TemplateUsed(response, 'phonebook/home.html')
 
         unsubscribe_from_basket_task_mock.assert_called_with(
-            user.email, user.userprofile.basket_token)
+            user.email, user.userprofile.basket_token, ['newsletter'])
         unindex_objects_mock.assert_has_calls([
             call(UserProfileMappingType, [user.userprofile.id], public_index=False),
             call(UserProfileMappingType, [user.userprofile.id], public_index=True)])
@@ -68,6 +69,7 @@ class DeleteTests(TestCase):
 
     @patch('mozillians.users.models.unsubscribe_from_basket_task.delay')
     @patch('mozillians.users.models.unindex_objects.delay')
+    @override_settings(BASKET_VOUCHED_NEWSLETTER='newsletter')
     def test_delete_vouched(self, unindex_objects_mock,
                             unsubscribe_from_basket_task_mock):
         user = UserFactory.create(userprofile={'basket_token': 'token'})
@@ -79,7 +81,7 @@ class DeleteTests(TestCase):
         self.assertJinja2TemplateUsed(response, 'phonebook/home.html')
 
         unsubscribe_from_basket_task_mock.assert_called_with(
-            user.email, user.userprofile.basket_token)
+            user.email, user.userprofile.basket_token, ['newsletter'])
         unindex_objects_mock.assert_has_calls([
             call(UserProfileMappingType, [user.userprofile.id], public_index=False),
             call(UserProfileMappingType, [user.userprofile.id], public_index=True)])

--- a/mozillians/settings/base.py
+++ b/mozillians/settings/base.py
@@ -430,7 +430,9 @@ if 'test' in sys.argv:
 else:
     # Basket requires SSL now for some calls
     BASKET_URL = 'https://basket.mozilla.com'
-BASKET_NEWSLETTER = 'mozilla-phone'
+
+BASKET_VOUCHED_NEWSLETTER = 'mozilla-phone'
+BASKET_NDA_NEWSLETTER = 'nda-mozillians'
 
 USER_AVATAR_DIR = 'uploads/userprofile'
 MOZSPACE_PHOTO_DIR = 'uploads/mozspaces'

--- a/mozillians/users/admin.py
+++ b/mozillians/users/admin.py
@@ -46,7 +46,7 @@ def subscribe_to_basket_action():
     def subscribe_to_basket(modeladmin, request, queryset):
         """Subscribe to Basket or update details of already subscribed."""
         ts = [(mozillians.users.tasks.update_basket_task
-               .subtask(args=[userprofile.id]))
+               .subtask(args=[userprofile.id, [settings.BASKET_VOUCHED_NEWSLETTER]]))
               for userprofile in queryset]
         TaskSet(ts).apply_async()
         messages.success(request, 'Basket update started.')
@@ -60,7 +60,8 @@ def unsubscribe_from_basket_action():
     def unsubscribe_from_basket(modeladmin, request, queryset):
         """Unsubscribe from Basket."""
         ts = [(mozillians.users.tasks.unsubscribe_from_basket_task
-               .subtask(args=[userprofile.user.email, userprofile.basket_token]))
+               .subtask(args=[userprofile.user.email, userprofile.basket_token,
+                              [settings.BASKET_VOUCHED_NEWSLETTER]]))
               for userprofile in queryset]
         TaskSet(ts).apply_async()
         messages.success(request, 'Basket update started.')

--- a/mozillians/users/models.py
+++ b/mozillians/users/models.py
@@ -630,10 +630,11 @@ def create_user_profile(sender, instance, created, raw, **kwargs):
 @receiver(dbsignals.post_save, sender=UserProfile,
           dispatch_uid='update_basket_sig')
 def update_basket(sender, instance, **kwargs):
+    newsletters = [settings.BASKET_VOUCHED_NEWSLETTER]
     if instance.is_vouched:
-        update_basket_task.delay(instance.id)
+        update_basket_task.delay(instance.id, newsletters)
     elif instance.basket_token:
-        unsubscribe_from_basket_task.delay(instance.email, instance.basket_token)
+        unsubscribe_from_basket_task.delay(instance.email, instance.basket_token, newsletters)
 
 
 @receiver(dbsignals.post_save, sender=UserProfile,
@@ -657,7 +658,8 @@ def remove_from_search_index(sender, instance, **kwargs):
 @receiver(dbsignals.pre_delete, sender=UserProfile,
           dispatch_uid='unsubscribe_from_basket_sig')
 def unsubscribe_from_basket(sender, instance, **kwargs):
-    unsubscribe_from_basket_task.delay(instance.email, instance.basket_token)
+    newsletters = [settings.BASKET_VOUCHED_NEWSLETTER]
+    unsubscribe_from_basket_task.delay(instance.email, instance.basket_token, newsletters)
 
 
 @receiver(dbsignals.post_delete, sender=UserProfile,


### PR DESCRIPTION
* Extend tasks to take `newsletters` as arg
* Add new `settings` entry for NDA basket
* When user changes email re-subscribe to all newsletters not only vouched