### PR TITLE
Refactor mass basket subscribe/unsubscribe admin actions

### DIFF
--- a/mozillians/settings/base.py
+++ b/mozillians/settings/base.py
@@ -433,6 +433,7 @@ else:
 
 BASKET_VOUCHED_NEWSLETTER = 'mozilla-phone'
 BASKET_NDA_NEWSLETTER = 'nda-mozillians'
+NDA_GROUP = "nda"
 
 USER_AVATAR_DIR = 'uploads/userprofile'
 MOZSPACE_PHOTO_DIR = 'uploads/mozspaces'

--- a/mozillians/users/admin.py
+++ b/mozillians/users/admin.py
@@ -230,6 +230,28 @@ class LegacyVouchFilter(SimpleListFilter):
         return queryset
 
 
+class NDAMemberFilter(SimpleListFilter):
+    """Admin filter for profiles member of the NDA group"""
+    title = "NDA member"
+    parameter_name = 'nda_member'
+
+    def lookups(self, request, model_admin):
+        return (('False', 'No'),
+                ('True', 'Yes'))
+
+    def queryset(self, request, queryset):
+        from mozillians.groups.models import Group, GroupMembership
+        group = Group.objects.get(name=settings.NDA_GROUP)
+        memberships = GroupMembership.objects.filter(group=group, status=GroupMembership.MEMBER)
+        profile_ids = memberships.values_list('userprofile__id', flat=True)
+
+        if self.value() == 'False':
+            return queryset.exclude(id__in=profile_ids)
+        elif self.value() == 'True':
+            return queryset.filter(id__in=profile_ids)
+        return queryset
+
+
 class UsernameBlacklistAdmin(ExportMixin, admin.ModelAdmin):
     """UsernameBlacklist Admin."""
     save_on_top = True
@@ -405,7 +427,7 @@ class UserProfileAdmin(AdminImageMixin, ExportMixin, admin.ModelAdmin):
     list_filter = ['is_vouched', 'can_vouch', DateJoinedFilter,
                    LastLoginFilter, LegacyVouchFilter, SuperUserFilter,
                    CompleteProfileFilter, PublicProfileFilter, AlternateEmailFilter,
-                   'externalaccount__type', 'referral_source']
+                   NDAMemberFilter, 'externalaccount__type', 'referral_source']
     save_on_top = True
     list_display = ['full_name', 'email', 'username', 'geo_country', 'is_vouched', 'can_vouch',
                     'number_of_vouchees']


### PR DESCRIPTION
* Make current basket admin actions newsletter agnostic
* [Fix bug 1282445] Mass delete subscription functionality on admin
* [Fix bug 1282446] Mass run of subscriptions from /admin/