### PR TITLE
Multiple L10N fixes

### DIFF
--- a/mozillians/common/middleware.py
+++ b/mozillians/common/middleware.py
@@ -96,7 +96,7 @@ class LocaleURLMiddleware(object):
     def process_request(self, request):
         # Don't apply middleware to requests matching exempt URLs
         for view_url in self.exempt_urls:
-            if view_url in request.path:
+            if re.match(view_url, request.path):
                 return None
 
         prefixer = urlresolvers.Prefixer(request)

--- a/mozillians/jinja2/includes/canonical_url.html
+++ b/mozillians/jinja2/includes/canonical_url.html
@@ -1,5 +1,5 @@
 <link rel="canonical" hreflang="{{ LANG }}" href="{{ settings.SITE_URL + '/' + LANG + canonical_path }}">
 <link rel="alternate" hreflang="x-default" href="{{ settings.SITE_URL + canonical_path }}">
-{% for code, name in LANGUAGES|dictsort -%}
+{% for code, name in LANGUAGES|sort -%}
   <link rel="alternate" hreflang="{{ code }}" href="{{ settings.SITE_URL + '/' + code + canonical_path }}" title="{{ name|safe }}">
 {% endfor -%}

--- a/mozillians/jinja2/includes/lang_switcher.html
+++ b/mozillians/jinja2/includes/lang_switcher.html
@@ -1,7 +1,7 @@
 <form id="language-switcher" class="languages go" method="GET">
   <select id="language" name="lang" dir="ltr">
     <option>{{ _('Select language') }}</option>
-      {% for code, name in LANGUAGES|dictsort -%}
+      {% for code, name in LANGUAGES|sort -%}
         <option value="{{ code }}" {{ code|ifeq(LANG|lower, "selected") }}>
           {{ name|safe }}
         </option>

--- a/mozillians/settings/base.py
+++ b/mozillians/settings/base.py
@@ -72,8 +72,11 @@ STANDALONE_DOMAINS = [TEXT_DOMAIN, 'djangojs']
 LANGUAGE_CODE = 'en-US'
 LOCALE_PATHS = [path('locale')]
 EXEMPT_L10N_URLS = [
-    '/oidc/authenticate/',
-    '/oidc/callback/'
+    '^/oidc/authenticate/',
+    '^/oidc/callback/',
+    '^/api/v1/',
+    '^/api/v2/',
+    '^/admin/'
 ]
 
 # Tells the extract script what files to parse for strings and what functions to use.
@@ -118,11 +121,11 @@ LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in get_langs()])
 def lazy_langs():
     from product_details import product_details
 
-    return dict([(lang.lower(), product_details.languages[lang]['native'])
-                 for lang in get_langs() if lang in product_details.languages])
+    return [(lang.lower(), product_details.languages[lang]['native'])
+            for lang in get_langs() if lang in product_details.languages]
 
 
-LANGUAGES = lazy(lazy_langs, dict)()
+LANGUAGES = lazy(lazy_langs, list)()
 
 # For absolute urls
 try:


### PR DESCRIPTION
* Exclude /api and /admin URLs from L10N middleware.
* Fix LANGUAGES definition format.
* Use regex for URLs that are not to be localized.