### PR TITLE
Update 'Get Involved' CTA to link Activate

### DIFF
--- a/mozillians/jinja2/phonebook/home.html
+++ b/mozillians/jinja2/phonebook/home.html
@@ -269,7 +269,7 @@
             lives of people everywhere.
             {% endtrans %}
           </p>
-          {% trans contribute_url='https://mozilla.org/contribute' %}
+          {% trans contribute_url='https://activate.mozilla.community/' %}
             <a href="{{ contribute_url }}">Get involved</a>
           {% endtrans %}
         </div>


### PR DESCRIPTION
As discussed, changing the 'Get Involved' CTA on front page to point to Activate, which is higher priority at the moment compared to the /contribute/ page.