### PR TITLE
Fixing docker environment for mysql database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 db:
   image: mysql:5.5
-  command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
+  command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci --max_allowed_packet=3M
   environment:
     - MYSQL_DATABASE=mozillians
     - MYSQL_USER=mozillians


### PR DESCRIPTION
We have a migration ``product_details.0002_auto_20151006_1348`` that makes ``'MySQL server has gone away'`` while running migration in docker environment.
I think, this patch should fix the issue.
I have tested on my local machine, and its working fine
@akatsoulas @johngian r?