### PR TITLE
Add cities_light loading to docker installation instructions

### DIFF
--- a/docs/installation/installation-docker.rst
+++ b/docs/installation/installation-docker.rst
@@ -64,6 +64,10 @@ Building mozillians
 
      $ docker-compose run web python manage.py update_product_details -f
 
+#. Import cities_light details:
+
+     $ docker-compose run web python manage.py cities_light
+
 #. Create the database tables and run the migrations::
 
      $ docker-compose run web python manage.py migrate --noinput


### PR DESCRIPTION
Was trying to get a docker instance up and running, and followed the docker installation instructions.  However, mozillians requires you to update the superuser profile you create in order to start using the app.  To do this, you need the country/region/city data loaded in the DB or it won't allow the user to advance through.  This update to the document is an attempt to make it so that others don't get hung up on this.