### PR TITLE
Fixes misaligned language select input

### DIFF
--- a/mozillians/static/mozillians/css/main.less
+++ b/mozillians/static/mozillians/css/main.less
@@ -826,7 +826,7 @@ footer#colophon {
         .box-shadow(0px 2px 4px rgba(0, 0, 0, 0.42));
         select {
             background: transparent;
-            width: 225px;
+            width: 200px;
             height: 25px;
             padding: 0 5px;
             font-size: 16px;
@@ -836,6 +836,8 @@ footer#colophon {
             line-height: 1.5;
             border: 0;
             cursor: pointer;
+            -moz-appearance: none;
+            -webkit-appearance: none;
         }
     }
     h5 {


### PR DESCRIPTION
This PR fixes a minor bug caused by the width of the form being different `from` the width of the `select` in the footer.

## Before

![before](https://twinnation.org/api/screenshots/2018-05-28_211956.png)


## After

![after](https://twinnation.org/api/screenshots/2018-05-28_214156.png)

