### PR TITLE
Readd Disable prefetch for the CIS queue.

### DIFF
--- a/bin/run-celery.sh
+++ b/bin/run-celery.sh
@@ -11,7 +11,7 @@ if [ $status -ne 0 ]; then
 fi
 
 # Run cis celery worker
-celery -A mozillians worker -Q cis -l INFO -n cis@%h -c $conc &
+celery -A mozillians worker -Q cis -l INFO -n cis@%h -Ofair -c $conc &
 status=$?
 if [ $status -ne 0 ]; then
     echo "Failed to start cis worker: $status"


### PR DESCRIPTION
Reverts mozilla/mozillians#2370
Now that the release is out we can test this properly without interfering with the rest of the Celery pipeline