### PR TITLE
Don't show an empty GitHub logo.

### DIFF
--- a/mozillians/jinja2/phonebook/profile.html
+++ b/mozillians/jinja2/phonebook/profile.html
@@ -118,7 +118,7 @@
               </section>
             {% endif %}
             {# Only show github primary accounts #}
-            {% if primary_identity.exists() and primary_identity[0].type == 30 % and primary_identity[0].username }
+            {% if primary_identity.exists() and primary_identity[0].type == 30 and primary_identity[0].username %}
               {% set idp = primary_identity[0] %}
               <section class="p-github">
                 <i class="icon-github"></i>

--- a/mozillians/jinja2/phonebook/profile.html
+++ b/mozillians/jinja2/phonebook/profile.html
@@ -118,7 +118,7 @@
               </section>
             {% endif %}
             {# Only show github primary accounts #}
-            {% if primary_identity.exists() and primary_identity[0].type == 30 %}
+            {% if primary_identity.exists() and primary_identity[0].type == 30 % and primary_identity[0].username }
               {% set idp = primary_identity[0] %}
               <section class="p-github">
                 <i class="icon-github"></i>


### PR DESCRIPTION
This potentially fixes empty GitHub logos.

![Screenshot](https://screenshotscdn.firefoxusercontent.com/images/3094b8b4-1eec-42c9-a7c4-0a70f2046f32.png)