### PR TITLE
Support privacy aware access to IDP emails.

### DIFF
--- a/mozillians/common/tests/test_authbackend.py
+++ b/mozillians/common/tests/test_authbackend.py
@@ -118,8 +118,10 @@ class MozilliansAuthBackendTests(TestCase):
         IdpProfile.objects.create(
             profile=user.userprofile,
             auth0_user_id='ad|foobar',
-            primary=True
+            primary=True,
+            email='foobar@example.com'
         )
+
         claims = {
             'email': 'bar@example.com',
             'user_id': 'foobar'

--- a/mozillians/users/models.py
+++ b/mozillians/users/models.py
@@ -334,7 +334,7 @@ class UserProfile(UserProfilePrivacyModel):
             # Try IDP contact first
             if self.idp_profiles.exists():
                 contact_ids = self.identity_profiles.filter(primary_contact_identity=True)
-                if contact_ids.exists():
+                if contact_ids.exists() and contact_ids[0].privacy < self._privacy_level:
                     return contact_ids[0].email
                 return ''
 
@@ -860,6 +860,12 @@ class IdpProfile(models.Model):
             self.primary_contact_identity = True
 
         super(IdpProfile, self).save(*args, **kwargs)
+
+        # Save profile.privacy_email when a primary contact identity changes
+        if self.primary_contact_identity:
+            profile = self.profile
+            profile.privacy_email = self.privacy
+            profile.save()
 
     def __unicode__(self):
         return u'{}|{}|{}'.format(self.profile, self.type, self.email)

--- a/mozillians/users/tests/test_models.py
+++ b/mozillians/users/tests/test_models.py
@@ -692,7 +692,6 @@ class EmailAttributeTests(TestCase):
 
     def test_existing_idp_privacy_not_allowed(self):
         profile = UserFactory.create(email='foo@foo.com').userprofile
-        profile.set_instance_privacy_level(PUBLIC)
         IdpProfile.objects.create(
             profile=profile,
             auth0_user_id='github|foo@bar.com',
@@ -701,6 +700,7 @@ class EmailAttributeTests(TestCase):
             primary_contact_identity=True,
             privacy=MOZILLIANS
         )
+        profile.set_instance_privacy_level(PUBLIC)
 
         eq_(profile.email, '')
 
@@ -805,11 +805,13 @@ class CISHelperMethodsTests(unittest.TestCase):
             profile=user.userprofile,
             auth0_user_id='github|foo@bar.com',
             primary=False,
+            email='foo@bar.com'
         )
         idp = IdpProfile.objects.create(
             profile=user.userprofile,
             auth0_user_id='ad|foo@bar.com',
             primary=True,
+            email='foo@bar.com'
         )
 
         eq_(set(user.userprofile.get_cis_groups(idp)),
@@ -828,11 +830,13 @@ class CISHelperMethodsTests(unittest.TestCase):
             profile=user.userprofile,
             auth0_user_id='github|foo@bar.com',
             primary=False,
+            email='foo@bar.com'
         )
         IdpProfile.objects.create(
             profile=user.userprofile,
             auth0_user_id='ad|foo@bar.com',
             primary=True,
+            email='foo@bar.com'
         )
 
         eq_(user.userprofile.get_cis_groups(idp), [])
@@ -873,6 +877,7 @@ class CISHelperMethodsTests(unittest.TestCase):
             profile=user1.userprofile,
             auth0_user_id='github|foo@bar.com',
             primary=False,
+            email='foo@bar.com'
         )
 
         eq_(user.userprofile.get_cis_groups(idp), [])
@@ -892,6 +897,7 @@ class CISHelperMethodsTests(unittest.TestCase):
             profile=user.userprofile,
             auth0_user_id='ad|foo@bar.com',
             primary=True,
+            email='foo@bar.com'
         )
 
         eq_(set(user.userprofile.get_cis_tags()),


### PR DESCRIPTION
* Return privacy aware IDP when accessing profile.email
* Change UserProfile.privacy_email when saving primary identity