### PR TITLE
Remove prompt param in account linking trigger

### DIFF
--- a/mozillians/phonebook/views.py
+++ b/mozillians/phonebook/views.py
@@ -589,8 +589,7 @@ class VerifyIdentityView(OIDCAuthenticationRequestView):
                 request,
                 nonprefixed_url('phonebook:verify_identity_callback')
             ),
-            'state': state,
-            'prompt': settings.OIDC_PROMPT
+            'state': state
         }
 
         if import_from_settings('OIDC_USE_NONCE', True):


### PR DESCRIPTION
This parameter, although it follows OIDC standard, has recently started causing Firefox Accounts to error, as described in https://github.com/mozilla-iam/auth0-custom-lock/issues/182. This week the issue also started happening in PROD, hence my proposal to remove the parameter for now.

We're still passing the `account_linking=true` parameter, I have updated NLX DEV to respect that the same way as `prompt=select_account`. 

When releasing to PROD, we should release NLX to PROD first, then Mozillians.