### PR TITLE
Activate en-CA locale

### DIFF
--- a/mozillians/settings.py
+++ b/mozillians/settings.py
@@ -162,7 +162,7 @@ STANDALONE_DOMAINS = [TEXT_DOMAIN, 'djangojs']
 LANGUAGE_CODE = config('LANGUAGE_CODE', default='en-US')
 LOCALE_PATHS = [Path('locale').resolve()]
 # Accepted locales
-PROD_LANGUAGES = ('ca', 'cs', 'de', 'en-US', 'en-GB', 'es', 'hu', 'fr', 'it', 'ko',
+PROD_LANGUAGES = ('ca', 'cs', 'de', 'en-CA', 'en-US', 'en-GB', 'es', 'hu', 'fr', 'it', 'ko',
                   'nl', 'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sl', 'sq', 'sr',
                   'sv-SE', 'te', 'zh-TW', 'zh-CN', 'lt', 'ja', 'hsb', 'dsb', 'uk', 'kab',
                   'fy-NL',)


### PR DESCRIPTION
I have localized the site to [Canadian English (en-CA)](https://github.com/mozilla-l10n/mozillians-l10n/tree/master/en_CA). Please activate the new locale. Thanks!