### PR TITLE
adding S3 media storage backend support

### DIFF
--- a/mozillians/settings.py
+++ b/mozillians/settings.py
@@ -715,6 +715,14 @@ GRAPHENE = {
     'SCHEMA': 'mozillians.schema.schema',
 }
 
+# Provide S3 storage backend
+if not DEV:
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+    AWS_STORAGE_BUCKET_NAME = config('AWS_STORAGE_BUCKET_NAME',
+                                     default='kubernetes-mozillians-stage')
+    DEFAULT_AVATAR_PATH = config('DEFAULT_AVATAR_PATH', default=urljoin(MEDIA_URL, DEFAULT_AVATAR))
+    CSP_IMG_SRC = CSP_IMG_SRC + ('https://' + AWS_STORAGE_BUCKET_NAME + '.s3.amazonaws.com',)
+
 # Dino Park configuration
 DINO_PARK_SEARCH_SVC = config('DINO_PARK_SEARCH_SVC', default='dino-park-search-service')
 DINO_PARK_ORGCHART_SVC = config('DINO_PARK_ORGCHART_SVC', default='dino-tree-service')


### PR DESCRIPTION
I would like to merge my work from iam-infra-migration (https://github.com/mozilla/mozillians/pull/2850) into the dino-park branch. Once this is added, we can close the other PR and I can use CodeBuild to build and deploy the container image to ECR / update the Kubernetes deployment from changes on this branch.