### PR TITLE
removes hard-coded namespace in configmap

### DIFF
--- a/k8s/templates/configmap.yml
+++ b/k8s/templates/configmap.yml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: mozillians-config
-  namespace: dino-park
+  namespace: {{ .Values.namespace }}
 data:
   ALLOWED_HOSTS: 'dinopark.mozilla.community, 127.0.0.1'
   BASKET_API_KEY: 'basket_api_key'


### PR DESCRIPTION
Hey,

This is currently resulting in failed deployments in Kubernetes (dinopark-dev namespace). Once this is merged, I can trigger a build to update the running pods.