### PR TITLE
Add oidc access group

### DIFF
--- a/k8s/templates/oidc-proxy.yaml
+++ b/k8s/templates/oidc-proxy.yaml
@@ -51,6 +51,11 @@ spec:
                 secretKeyRef:
                   name: oidc-proxy-secret
                   key: redirect_uri
+            - name: allowed_group
+              valueFrom:
+                secretKeyRef:
+                  key: allowed_group
+                  name: oidc-proxy-secret
 
 ---
 apiVersion: v1

--- a/k8s/templates/oidc-proxy.yaml
+++ b/k8s/templates/oidc-proxy.yaml
@@ -36,11 +36,6 @@ spec:
                 secretKeyRef:
                   name: oidc-proxy-secret
                   key: discovery_url
-            - name: discovery_url
-              valueFrom:
-                secretKeyRef:
-                  name: oidc-proxy-secret
-                  key: discovery_url
             - name: backend
               valueFrom:
                 secretKeyRef:
@@ -54,8 +49,8 @@ spec:
             - name: allowed_group
               valueFrom:
                 secretKeyRef:
-                  key: allowed_group
                   name: oidc-proxy-secret
+                  key: allowed_group
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Adding the group reference as an environment variable sourced from the Kubernetes secret. I also noticed a duplicate discovery_url secret so I removed it.